### PR TITLE
feat: update vite dependency to use latest version

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@^0.1.14
+        specifier: npm:@voidzero-dev/vite-plus-core@latest
         version: '@voidzero-dev/vite-plus-core@0.1.14(jiti@2.6.1)(terser@5.46.1)(typescript@6.0.2)'
       vite-plugin-pwa:
         specifier: ^1.2.0


### PR DESCRIPTION
This pull request makes a small update to the `pnpm-lock.yaml` file, changing the version specifier for the `vite` package from a fixed version (`^0.1.14`) to always use the latest version of `@voidzero-dev/vite-plus-core`.