### PR TITLE
Enhance ReorderPages component and implement PDF page management

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Build
         run: vp run build
         env:
-          VITE_APP_BASE_PATH: /bytepdf/
+          # Base path is "/" because a custom domain (bytepdf.app) is active.
+          # GitHub Pages automatically redirects sumitsahoo.github.io/bytepdf/ → bytepdf.app.
+          # If you ever remove the custom domain, revert this to /bytepdf/
+          VITE_APP_BASE_PATH: /
 
       # - name: Test
       #   run: vp run test

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@^0.1.15
+        specifier: npm:@voidzero-dev/vite-plus-core@latest
         version: '@voidzero-dev/vite-plus-core@0.1.15(jiti@2.6.1)(terser@5.46.1)(typescript@6.0.2)'
       vite-plugin-pwa:
         specifier: ^1.2.0

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+bytepdf.app

--- a/src/tools/AddBlankPage.tsx
+++ b/src/tools/AddBlankPage.tsx
@@ -1,29 +1,37 @@
 /**
  * Add Blank Page tool.
  *
- * Loads a PDF and displays its pages as thumbnails. The user drags the
- * blank page placeholder to the desired insertion position.
+ * Loads a PDF and displays its pages as thumbnails in a wrapping grid
+ * (matching the ReorderPages layout). The user can add one or more blank
+ * pages, drag any item to reorder, and download the result.
  */
 
 import { useState, useCallback } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
-import { addBlankPage } from "../utils/pdf-operations.ts";
+import { addBlankPages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
+
+type BlankItem = { type: "blank"; id: string };
+type OriginalItem = { type: "original"; index: number };
+type PageItem = BlankItem | OriginalItem;
+
+let blankCounter = 0;
+function nextBlankId() {
+  return `blank-${++blankCounter}-${Date.now()}`;
+}
 
 export default function AddBlankPage() {
   const [file, setFile] = useState<File | null>(null);
   const [thumbnails, setThumbnails] = useState<string[]>([]);
-  // Stable IDs for thumbnails to avoid index-based keys.
-  const [thumbnailIds, setThumbnailIds] = useState<string[]>([]);
-  // insertPosition is the 0-based index at which the blank page will be inserted.
-  // 0 = before page 1, thumbnails.length = after the last page.
-  const [insertPosition, setInsertPosition] = useState(0);
+  const [items, setItems] = useState<PageItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragOverPosition, setDragOverPosition] = useState<number | null>(null);
+
+  // Drag state
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
 
   const handleFile = useCallback(async (files: File[]) => {
     const pdf = files[0];
@@ -34,8 +42,9 @@ export default function AddBlankPage() {
     try {
       const thumbs = await renderAllThumbnails(pdf);
       setThumbnails(thumbs);
-      setThumbnailIds(thumbs.map((_, idx) => `thumb-${idx}-${Date.now()}`));
-      setInsertPosition(thumbs.length); // default: append at end
+      // Default: one blank page at the start
+      const originals: PageItem[] = thumbs.map((_, i) => ({ type: "original" as const, index: i }));
+      setItems([{ type: "blank", id: nextBlankId() }, ...originals]);
     } catch (e) {
       setError(
         e instanceof Error
@@ -48,116 +57,192 @@ export default function AddBlankPage() {
     }
   }, []);
 
-  const handleInsert = useCallback(async () => {
-    if (!file) return;
+  const hasBlankPages = items.some((it) => it.type === "blank");
+  const isDragging = dragIndex !== null;
+
+  const handleAddBlank = useCallback(() => {
+    setItems((prev) => [{ type: "blank", id: nextBlankId() }, ...prev]);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setItems((prev) => prev.filter((it) => it.type === "original"));
+    setDragIndex(null);
+    setDragOverSlot(null);
+  }, []);
+
+  const handleApply = useCallback(async () => {
+    if (!file || !hasBlankPages) return;
     setProcessing(true);
     setError(null);
     try {
-      const result = await addBlankPage(file, insertPosition);
+      // Compute the 0-based positions (relative to the original page list)
+      // where blank pages should be inserted.
+      const positions: number[] = [];
+      let originalsSeen = 0;
+      for (const it of items) {
+        if (it.type === "blank") {
+          positions.push(originalsSeen);
+        } else {
+          originalsSeen++;
+        }
+      }
+      const result = await addBlankPages(file, positions);
       const baseName = file.name.replace(/\.pdf$/i, "");
       downloadPdf(result, `${baseName}_blank_added.pdf`);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to insert blank page. Please try again.");
+      setError(e instanceof Error ? e.message : "Failed to insert blank pages. Please try again.");
     } finally {
       setProcessing(false);
     }
-  }, [file, insertPosition]);
+  }, [file, hasBlankPages, items]);
 
-  const positionLabel =
-    insertPosition === 0
-      ? "Before page 1 (at the beginning)"
-      : insertPosition === thumbnails.length
-        ? `After page ${thumbnails.length} (at the end)`
-        : `Before page ${insertPosition + 1}`;
+  const renderItems = () => {
+    const elements: React.ReactNode[] = [];
 
-  // Single stable layout: [dropzone_0] [page_0] [dropzone_1] [page_1] ... [page_N-1] [dropzone_N]
-  // The dropzone at insertPosition renders the draggable "New" card.
-  // Other dropzones are invisible gaps that expand into drop targets while dragging.
-  // Keeping the DOM structure stable prevents the drag from being cancelled when
-  // the draggable element would otherwise be removed on re-render.
-  const renderPageRow = () => {
-    const items: React.ReactNode[] = [];
+    for (let slot = 0; slot <= items.length; slot++) {
+      // ── Drop zone ──
+      const isAdjacentToDrag = dragIndex !== null && (slot === dragIndex || slot === dragIndex + 1);
 
-    for (let i = 0; i <= thumbnails.length; i++) {
-      const isInsertHere = i === insertPosition;
-      const isOver = dragOverPosition === i;
-      const dropId = thumbnailIds[i] ?? "drop-end";
-
-      if (isInsertHere) {
-        items.push(
-          <button
-            key="new-blank-page"
-            type="button"
-            draggable
-            onDragStart={(e) => {
-              e.dataTransfer.effectAllowed = "move";
-              setIsDragging(true);
-            }}
-            onDragEnd={() => {
-              setIsDragging(false);
-              setDragOverPosition(null);
-            }}
-            className="shrink-0 flex flex-col items-center gap-1 cursor-grab active:cursor-grabbing border-0 bg-transparent p-0"
-          >
-            <div className="w-16 aspect-3/4 rounded-lg border-2 border-dashed border-primary-400 bg-primary-50 dark:bg-primary-900/20 flex items-center justify-center">
-              <span className="text-primary-500 text-xl font-light">+</span>
-            </div>
-            <span className="text-xs text-primary-500 font-medium">New</span>
-          </button>,
-        );
-      } else {
-        items.push(
-          <button
-            key={`drop-${dropId}`}
-            type="button"
-            aria-label={`Insert before page ${i + 1}`}
-            onDragOver={(e) => {
-              e.preventDefault();
-              setDragOverPosition(i);
-            }}
-            onDragLeave={(e) => {
-              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                setDragOverPosition(null);
-              }
-            }}
-            onDrop={(e) => {
-              e.preventDefault();
-              setInsertPosition(i);
-              setIsDragging(false);
-              setDragOverPosition(null);
-            }}
-            className={`shrink-0 self-stretch flex items-center justify-center rounded-lg transition-all duration-150 border-0 bg-transparent p-0 ${
-              isDragging ? (isOver ? "w-16 bg-primary-50 dark:bg-primary-900/20" : "w-4") : "w-1"
-            }`}
-          >
-            {isDragging && (
-              <div
-                className={`rounded-full transition-all duration-150 ${
-                  isOver
-                    ? "w-1 h-14 bg-primary-500"
-                    : "w-0.5 h-10 bg-primary-200 dark:bg-primary-800"
-                }`}
-              />
-            )}
-          </button>,
-        );
-      }
-
-      if (i < thumbnails.length) {
-        items.push(
-          <div key={thumbnailIds[i]} className="shrink-0 flex flex-col items-center gap-1">
-            <img
-              src={thumbnails[i]}
-              className="w-16 aspect-3/4 object-cover rounded-lg border border-slate-200 dark:border-dark-border"
-              alt={`Page ${i + 1}`}
+      elements.push(
+        <div
+          key={`drop-${slot}`}
+          onDragOver={(e) => {
+            if (isAdjacentToDrag) return;
+            e.preventDefault();
+            setDragOverSlot(slot);
+          }}
+          onDragLeave={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+              if (dragOverSlot === slot) setDragOverSlot(null);
+            }
+          }}
+          onDrop={(e) => {
+            e.preventDefault();
+            if (dragIndex === null || isAdjacentToDrag) return;
+            setItems((prev) => {
+              const next = [...prev];
+              const [moved] = next.splice(dragIndex, 1);
+              const adjustedSlot = dragIndex < slot ? slot - 1 : slot;
+              next.splice(adjustedSlot, 0, moved);
+              return next;
+            });
+            setDragIndex(null);
+            setDragOverSlot(null);
+          }}
+          className={`self-stretch flex items-center justify-center rounded-lg transition-all duration-200 ${
+            isDragging && !isAdjacentToDrag
+              ? dragOverSlot === slot
+                ? "w-20 sm:w-24 bg-primary-50 dark:bg-primary-900/20"
+                : "w-3 sm:w-4"
+              : "w-0"
+          }`}
+        >
+          {isDragging && !isAdjacentToDrag && (
+            <div
+              className={`rounded-full transition-all duration-200 ${
+                dragOverSlot === slot
+                  ? "w-1 bg-primary-500"
+                  : "w-0.5 bg-primary-200 dark:bg-primary-800"
+              }`}
+              style={{ height: dragOverSlot === slot ? "80%" : "60%" }}
             />
-            <span className="text-xs text-slate-400 dark:text-dark-text-muted">{i + 1}</span>
-          </div>,
-        );
+          )}
+        </div>,
+      );
+
+      // ── Page card ──
+      if (slot < items.length) {
+        const item = items[slot];
+        const isSource = dragIndex === slot;
+
+        if (item.type === "blank") {
+          elements.push(
+            <div
+              key={item.id}
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.effectAllowed = "move";
+                setDragIndex(slot);
+              }}
+              onDragEnd={() => {
+                setDragIndex(null);
+                setDragOverSlot(null);
+              }}
+              className={`shrink-0 pt-2 pr-2 flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none transition-all duration-200 ${
+                isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"
+              }`}
+            >
+              <div className="relative">
+                <div
+                  className={`w-20 sm:w-24 md:w-28 aspect-[3/4] rounded-lg border-2 border-dashed flex items-center justify-center transition-colors shadow-sm ${
+                    isSource
+                      ? "border-slate-300 dark:border-dark-border bg-slate-50 dark:bg-dark-surface"
+                      : "border-primary-400 bg-primary-50 dark:bg-primary-900/20"
+                  }`}
+                >
+                  <span className="text-primary-500 text-2xl font-light">+</span>
+                </div>
+                <div
+                  className={`absolute -top-1.5 -right-1.5 text-white text-[10px] font-bold px-1.5 h-5 rounded-full flex items-center justify-center shadow-md z-10 transition-opacity duration-200 ${
+                    isSource ? "bg-slate-400 dark:bg-slate-600 opacity-50" : "bg-primary-600"
+                  }`}
+                >
+                  New
+                </div>
+              </div>
+              <span className="text-xs font-medium text-primary-500">Blank</span>
+            </div>,
+          );
+        } else {
+          elements.push(
+            <div
+              key={`page-${item.index}`}
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.effectAllowed = "move";
+                setDragIndex(slot);
+              }}
+              onDragEnd={() => {
+                setDragIndex(null);
+                setDragOverSlot(null);
+              }}
+              className={`shrink-0 pt-2 pr-2 flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none transition-all duration-200 ${
+                isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"
+              }`}
+            >
+              <div className="relative">
+                <div
+                  className={`w-20 sm:w-24 md:w-28 aspect-[3/4] bg-white dark:bg-dark-surface rounded-lg overflow-hidden border-2 transition-colors shadow-sm ${
+                    isSource
+                      ? "border-dashed border-slate-300 dark:border-dark-border"
+                      : "border-slate-200 dark:border-dark-border hover:border-primary-300 dark:hover:border-primary-600"
+                  }`}
+                >
+                  <img
+                    src={thumbnails[item.index]}
+                    className="w-full h-full object-contain"
+                    alt={`Page ${item.index + 1}`}
+                    draggable={false}
+                  />
+                </div>
+                <div
+                  className={`absolute -top-1.5 -right-1.5 text-white text-xs font-bold w-6 h-6 rounded-full flex items-center justify-center shadow-md z-10 transition-opacity duration-200 ${
+                    isSource ? "bg-slate-400 dark:bg-slate-600 opacity-50" : "bg-primary-600"
+                  }`}
+                >
+                  {item.index + 1}
+                </div>
+              </div>
+              <span className="text-xs font-medium text-slate-500 dark:text-dark-text-muted">
+                Page {item.index + 1}
+              </span>
+            </div>,
+          );
+        }
       }
     }
 
-    return items;
+    return elements;
   };
 
   return (
@@ -167,7 +252,7 @@ export default function AddBlankPage() {
           accept=".pdf,application/pdf"
           onFiles={handleFile}
           label="Drop a PDF file here"
-          hint="A blank page will be inserted at your chosen position"
+          hint="Add one or more blank pages and drag to set their position"
         />
       ) : (
         <>
@@ -180,7 +265,7 @@ export default function AddBlankPage() {
               onClick={() => {
                 setFile(null);
                 setThumbnails([]);
-                setThumbnailIds([]);
+                setItems([]);
               }}
               className="text-sm text-primary-600 hover:text-primary-700"
             >
@@ -194,26 +279,77 @@ export default function AddBlankPage() {
             </div>
           ) : (
             <>
-              <div className="space-y-2">
-                <p className="text-sm font-medium text-slate-700 dark:text-dark-text">
-                  {isDragging
-                    ? "Drop the page at the desired position"
-                    : "Drag the new page to set its position"}
-                </p>
-                <div className="flex items-end gap-2 overflow-x-auto pb-2 min-h-22">
-                  {renderPageRow()}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium text-slate-700 dark:text-dark-text">
+                    {isDragging
+                      ? "Drop the page at its new position"
+                      : "Drag pages to rearrange them"}
+                  </p>
+                  <div className="flex items-center gap-3">
+                    {hasBlankPages && (
+                      <button
+                        type="button"
+                        onClick={handleReset}
+                        className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted dark:hover:text-dark-text transition-colors"
+                      >
+                        <svg
+                          className="w-4 h-4"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth={2}
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M3 10h10a5 5 0 0 1 5 5v2M3 10l4-4m-4 4l4 4" />
+                        </svg>
+                        Reset
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={handleAddBlank}
+                      className="inline-flex items-center gap-1.5 text-sm text-primary-600 hover:text-primary-700 font-medium transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M12 5v14m-7-7h14" />
+                      </svg>
+                      Add blank page
+                    </button>
+                  </div>
                 </div>
-                <p className="text-sm text-primary-600 font-medium">{positionLabel}</p>
+
+                <div className="flex flex-wrap items-end gap-y-6 overflow-x-auto pb-2 min-h-28">
+                  {renderItems()}
+                </div>
+
+                {hasBlankPages && (
+                  <p className="text-xs text-primary-600 dark:text-primary-400 font-medium">
+                    {items.filter((it) => it.type === "blank").length} blank page(s) added — click
+                    below to apply
+                  </p>
+                )}
               </div>
 
-              <button
-                type="button"
-                onClick={handleInsert}
-                disabled={processing}
-                className="w-full bg-primary-600 text-white py-3 px-6 rounded-xl font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-              >
-                {processing ? "Inserting…" : "Insert Blank Page & Download"}
-              </button>
+              {hasBlankPages && (
+                <button
+                  type="button"
+                  onClick={handleApply}
+                  disabled={processing}
+                  className="w-full bg-primary-600 text-white py-3 px-6 rounded-xl font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {processing ? "Inserting…" : "Insert Blank Pages & Download"}
+                </button>
+              )}
             </>
           )}
         </>

--- a/src/tools/DuplicatePage.tsx
+++ b/src/tools/DuplicatePage.tsx
@@ -1,44 +1,48 @@
 /**
  * Duplicate Page tool.
  *
- * Displays all PDF pages as thumbnails. The user selects one page to
- * duplicate, then drags the copy placeholder to choose where it is inserted.
- * The resulting PDF is downloaded immediately.
+ * Single unified grid: click any page to add a copy at position 0.
+ * Click again (same or different page) to add more copies.
+ * All items are draggable so the user can reposition copies, then download.
  */
 
 import { useCallback, useState } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
-import { PageThumbnail } from "../components/PageThumbnail.tsx";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
-import { duplicatePage } from "../utils/pdf-operations.ts";
+import { duplicatePages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
+
+type CopyItem = { type: "copy"; sourceIndex: number; id: string };
+type OriginalItem = { type: "original"; index: number };
+type PageItem = CopyItem | OriginalItem;
+
+let copyCounter = 0;
+function nextCopyId() {
+  return `copy-${++copyCounter}-${Date.now()}`;
+}
 
 export default function DuplicatePage() {
   const [file, setFile] = useState<File | null>(null);
   const [thumbnails, setThumbnails] = useState<string[]>([]);
-  // Stable IDs for thumbnails to avoid index-based keys.
-  const [thumbnailIds, setThumbnailIds] = useState<string[]>([]);
-  const [selectedPage, setSelectedPage] = useState<number | null>(null);
-  // targetPosition: 0-based index at which the copy is inserted.
-  const [targetPosition, setTargetPosition] = useState(0);
+  const [items, setItems] = useState<PageItem[]>([]);
   const [loading, setLoading] = useState(false);
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragOverPosition, setDragOverPosition] = useState<number | null>(null);
+
+  // Drag state
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
 
   const handleFile = useCallback(async (files: File[]) => {
     const pdf = files[0];
     if (!pdf) return;
     setFile(pdf);
-    setSelectedPage(null);
     setError(null);
     setLoading(true);
     try {
       const thumbs = await renderAllThumbnails(pdf);
       setThumbnails(thumbs);
-      setThumbnailIds(thumbs.map((_, idx) => `thumb-${idx}-${Date.now()}`));
-      setTargetPosition(thumbs.length); // default: insert copy at end
+      setItems(thumbs.map((_, i) => ({ type: "original" as const, index: i })));
     } catch (e) {
       setError(
         e instanceof Error
@@ -51,116 +55,204 @@ export default function DuplicatePage() {
     }
   }, []);
 
-  const handleDuplicate = useCallback(async () => {
-    if (!file || selectedPage === null) return;
+  const hasCopies = items.some((it) => it.type === "copy");
+  const isDragging = dragIndex !== null;
+
+  const handleDuplicatePage = useCallback((pageIndex: number) => {
+    setItems((prev) => [{ type: "copy", sourceIndex: pageIndex, id: nextCopyId() }, ...prev]);
+  }, []);
+
+  const handleReset = useCallback(() => {
+    setItems((prev) => prev.filter((it) => it.type === "original"));
+    setDragIndex(null);
+    setDragOverSlot(null);
+  }, []);
+
+  const handleApply = useCallback(async () => {
+    if (!file || !hasCopies) return;
     setProcessing(true);
     setError(null);
     try {
-      const result = await duplicatePage(file, selectedPage, targetPosition);
+      // Compute copy positions relative to the original page list.
+      const copies: { sourceIndex: number; position: number }[] = [];
+      let originalsSeen = 0;
+      for (const it of items) {
+        if (it.type === "copy") {
+          copies.push({ sourceIndex: it.sourceIndex, position: originalsSeen });
+        } else {
+          originalsSeen++;
+        }
+      }
+      const result = await duplicatePages(file, copies);
       const baseName = file.name.replace(/\.pdf$/i, "");
       downloadPdf(result, `${baseName}_duplicated.pdf`);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to duplicate page. Please try again.");
+      setError(e instanceof Error ? e.message : "Failed to duplicate pages. Please try again.");
     } finally {
       setProcessing(false);
     }
-  }, [file, selectedPage, targetPosition]);
+  }, [file, hasCopies, items]);
 
-  // Single stable layout: [dropzone_0] [page_0] [dropzone_1] ... [page_N-1] [dropzone_N]
-  // The dropzone at targetPosition renders the draggable "Copy" card.
-  // Other dropzones are thin gaps that expand into drop targets while dragging.
-  const renderCopyRow = () => {
-    if (selectedPage === null) return null;
-    const items: React.ReactNode[] = [];
+  const renderItems = () => {
+    const elements: React.ReactNode[] = [];
 
-    for (let i = 0; i <= thumbnails.length; i++) {
-      const isInsertHere = i === targetPosition;
-      const isOver = dragOverPosition === i;
-      const dropId = thumbnailIds[i] ?? "drop-end";
+    for (let slot = 0; slot <= items.length; slot++) {
+      // ── Drop zone ──
+      const isAdjacentToDrag = dragIndex !== null && (slot === dragIndex || slot === dragIndex + 1);
 
-      if (isInsertHere) {
-        items.push(
-          <button
-            key="copy-page"
-            type="button"
-            draggable
-            onDragStart={(e) => {
-              e.dataTransfer.effectAllowed = "move";
-              setIsDragging(true);
-            }}
-            onDragEnd={() => {
-              setIsDragging(false);
-              setDragOverPosition(null);
-            }}
-            className="shrink-0 flex flex-col items-center gap-1 cursor-grab active:cursor-grabbing border-0 bg-transparent p-0"
-          >
-            <div className="relative w-16 aspect-3/4">
-              <img
-                src={thumbnails[selectedPage]}
-                className="w-full h-full object-cover rounded-lg border-2 border-primary-400"
-                alt={`Copy of page ${selectedPage + 1}`}
-              />
-              <div className="absolute inset-0 bg-primary-500/20 rounded-lg" />
-            </div>
-            <span className="text-xs text-primary-500 font-medium">Copy</span>
-          </button>,
-        );
-      } else {
-        items.push(
-          <button
-            key={`drop-${dropId}`}
-            type="button"
-            aria-label={`Insert copy before page ${i + 1}`}
-            onDragOver={(e) => {
-              e.preventDefault();
-              setDragOverPosition(i);
-            }}
-            onDragLeave={(e) => {
-              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                setDragOverPosition(null);
-              }
-            }}
-            onDrop={(e) => {
-              e.preventDefault();
-              setTargetPosition(i);
-              setIsDragging(false);
-              setDragOverPosition(null);
-            }}
-            className={`shrink-0 self-stretch flex items-center justify-center rounded-lg transition-all duration-150 border-0 bg-transparent p-0 ${
-              isDragging ? (isOver ? "w-16 bg-primary-50 dark:bg-primary-900/20" : "w-4") : "w-1"
-            }`}
-          >
-            {isDragging && (
-              <div
-                className={`rounded-full transition-all duration-150 ${
-                  isOver
-                    ? "w-1 h-14 bg-primary-500"
-                    : "w-0.5 h-10 bg-primary-200 dark:bg-primary-800"
-                }`}
-              />
-            )}
-          </button>,
-        );
-      }
-
-      if (i < thumbnails.length) {
-        items.push(
-          <div key={thumbnailIds[i]} className="shrink-0 flex flex-col items-center gap-1">
-            <img
-              src={thumbnails[i]}
-              className="w-16 aspect-3/4 object-cover rounded-lg border border-slate-200 dark:border-dark-border"
-              alt={`Page ${i + 1}`}
+      elements.push(
+        <div
+          key={`drop-${slot}`}
+          onDragOver={(e) => {
+            if (isAdjacentToDrag) return;
+            e.preventDefault();
+            setDragOverSlot(slot);
+          }}
+          onDragLeave={(e) => {
+            if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+              if (dragOverSlot === slot) setDragOverSlot(null);
+            }
+          }}
+          onDrop={(e) => {
+            e.preventDefault();
+            if (dragIndex === null || isAdjacentToDrag) return;
+            setItems((prev) => {
+              const next = [...prev];
+              const [moved] = next.splice(dragIndex, 1);
+              const adjustedSlot = dragIndex < slot ? slot - 1 : slot;
+              next.splice(adjustedSlot, 0, moved);
+              return next;
+            });
+            setDragIndex(null);
+            setDragOverSlot(null);
+          }}
+          className={`self-stretch flex items-center justify-center rounded-lg transition-all duration-200 ${
+            isDragging && !isAdjacentToDrag
+              ? dragOverSlot === slot
+                ? "w-20 sm:w-24 bg-primary-50 dark:bg-primary-900/20"
+                : "w-3 sm:w-4"
+              : "w-0"
+          }`}
+        >
+          {isDragging && !isAdjacentToDrag && (
+            <div
+              className={`rounded-full transition-all duration-200 ${
+                dragOverSlot === slot
+                  ? "w-1 bg-primary-500"
+                  : "w-0.5 bg-primary-200 dark:bg-primary-800"
+              }`}
+              style={{ height: dragOverSlot === slot ? "80%" : "60%" }}
             />
-            <span className="text-xs text-slate-400 dark:text-dark-text-muted">{i + 1}</span>
-          </div>,
-        );
+          )}
+        </div>,
+      );
+
+      // ── Page card ──
+      if (slot < items.length) {
+        const item = items[slot];
+        const isSource = dragIndex === slot;
+
+        if (item.type === "copy") {
+          elements.push(
+            <div
+              key={item.id}
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.effectAllowed = "move";
+                setDragIndex(slot);
+              }}
+              onDragEnd={() => {
+                setDragIndex(null);
+                setDragOverSlot(null);
+              }}
+              className={`shrink-0 p-2 flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none transition-all duration-200 ${
+                isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"
+              }`}
+            >
+              <div className="relative">
+                <div
+                  className={`w-20 sm:w-24 md:w-28 aspect-[3/4] bg-white dark:bg-dark-surface rounded-lg overflow-hidden border-2 transition-colors shadow-sm ${
+                    isSource
+                      ? "border-dashed border-slate-300 dark:border-dark-border"
+                      : "border-primary-400"
+                  }`}
+                >
+                  <img
+                    src={thumbnails[item.sourceIndex]}
+                    className="w-full h-full object-contain"
+                    alt={`Copy of page ${item.sourceIndex + 1}`}
+                    draggable={false}
+                  />
+                  <div className="absolute inset-0 bg-primary-500/20 rounded-lg" />
+                </div>
+                <div
+                  className={`absolute -top-1.5 -right-1.5 text-white text-[10px] font-bold px-1.5 h-5 rounded-full flex items-center justify-center shadow-md z-10 transition-opacity duration-200 ${
+                    isSource ? "bg-slate-400 dark:bg-slate-600 opacity-50" : "bg-primary-600"
+                  }`}
+                >
+                  Copy
+                </div>
+              </div>
+              <span className="text-xs font-medium text-primary-500">
+                Copy of {item.sourceIndex + 1}
+              </span>
+            </div>,
+          );
+        } else {
+          elements.push(
+            <div
+              key={`page-${item.index}`}
+              draggable={hasCopies}
+              onClick={() => {
+                if (!isDragging) handleDuplicatePage(item.index);
+              }}
+              onDragStart={(e) => {
+                if (!hasCopies) return;
+                e.dataTransfer.effectAllowed = "move";
+                setDragIndex(slot);
+              }}
+              onDragEnd={() => {
+                setDragIndex(null);
+                setDragOverSlot(null);
+              }}
+              className={`shrink-0 p-2 flex flex-col items-center gap-1.5 select-none transition-all duration-200 cursor-pointer ${
+                hasCopies ? "active:cursor-grabbing" : "hover:scale-105"
+              } ${isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"}`}
+            >
+              <div className="relative">
+                <div
+                  className={`w-20 sm:w-24 md:w-28 aspect-[3/4] bg-white dark:bg-dark-surface rounded-lg overflow-hidden border-2 transition-colors shadow-sm ${
+                    isSource
+                      ? "border-dashed border-slate-300 dark:border-dark-border"
+                      : "border-slate-200 dark:border-dark-border hover:border-primary-300 dark:hover:border-primary-600"
+                  }`}
+                >
+                  <img
+                    src={thumbnails[item.index]}
+                    className="w-full h-full object-contain"
+                    alt={`Page ${item.index + 1}`}
+                    draggable={false}
+                  />
+                </div>
+                <div
+                  className={`absolute -top-1.5 -right-1.5 text-white text-xs font-bold w-6 h-6 rounded-full flex items-center justify-center shadow-md z-10 transition-opacity duration-200 ${
+                    isSource ? "bg-slate-400 dark:bg-slate-600 opacity-50" : "bg-primary-600"
+                  }`}
+                >
+                  {item.index + 1}
+                </div>
+              </div>
+              <span className="text-xs font-medium text-slate-500 dark:text-dark-text-muted">
+                Page {item.index + 1}
+              </span>
+            </div>,
+          );
+        }
       }
     }
 
-    return items;
+    return elements;
   };
-
-  const insertLabel = targetPosition === 0 ? "At the beginning" : `After page ${targetPosition}`;
 
   return (
     <div className="space-y-6">
@@ -169,7 +261,7 @@ export default function DuplicatePage() {
           accept=".pdf,application/pdf"
           onFiles={handleFile}
           label="Drop a PDF file here"
-          hint="Click a page to select it, then drag the copy to choose where to place it"
+          hint="Click pages to duplicate them, then drag copies to position them"
         />
       ) : (
         <>
@@ -182,8 +274,7 @@ export default function DuplicatePage() {
               onClick={() => {
                 setFile(null);
                 setThumbnails([]);
-                setThumbnailIds([]);
-                setSelectedPage(null);
+                setItems([]);
               }}
               className="text-sm text-primary-600 hover:text-primary-700"
             >
@@ -197,68 +288,58 @@ export default function DuplicatePage() {
             </div>
           ) : (
             <>
-              <div>
-                <p className="text-sm font-medium text-slate-700 dark:text-dark-text mb-2">
-                  {selectedPage === null
-                    ? "Click a page to select it for duplication"
-                    : `Page ${selectedPage + 1} selected — drag the copy to set its position`}
-                </p>
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
-                  {thumbnails.map((thumb, i) => (
-                    <PageThumbnail
-                      key={thumbnailIds[i] ?? i}
-                      src={thumb}
-                      pageNumber={i + 1}
-                      selected={selectedPage === i}
-                      onClick={() => setSelectedPage(i === selectedPage ? null : i)}
-                      overlay={
-                        selectedPage === i ? (
-                          <div className="bg-primary-600/70 inset-0 absolute flex items-center justify-center">
-                            <svg
-                              className="w-7 h-7 text-white"
-                              fill="none"
-                              stroke="currentColor"
-                              viewBox="0 0 24 24"
-                              aria-hidden="true"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth={2}
-                                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                              />
-                            </svg>
-                          </div>
-                        ) : null
-                      }
-                    />
-                  ))}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium text-slate-700 dark:text-dark-text">
+                    {isDragging
+                      ? "Drop at the desired position"
+                      : hasCopies
+                        ? "Click a page to add another copy, or drag to rearrange"
+                        : "Click a page to duplicate it"}
+                  </p>
+                  {hasCopies && (
+                    <button
+                      type="button"
+                      onClick={handleReset}
+                      className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted dark:hover:text-dark-text transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M3 10h10a5 5 0 0 1 5 5v2M3 10l4-4m-4 4l4 4" />
+                      </svg>
+                      Reset
+                    </button>
+                  )}
                 </div>
+
+                <div className="flex flex-wrap items-end gap-y-6 pb-2 min-h-28">
+                  {renderItems()}
+                </div>
+
+                {hasCopies && (
+                  <p className="text-xs text-primary-600 dark:text-primary-400 font-medium">
+                    {items.filter((it) => it.type === "copy").length} copy(ies) added — click below
+                    to apply
+                  </p>
+                )}
               </div>
 
-              {selectedPage !== null && (
-                <div className="space-y-3">
-                  <div className="space-y-2">
-                    <p className="text-sm font-medium text-slate-700 dark:text-dark-text">
-                      {isDragging
-                        ? "Drop the copy at the desired position"
-                        : "Drag the copy to set its position"}
-                    </p>
-                    <div className="flex items-end gap-2 overflow-x-auto pb-2 min-h-22">
-                      {renderCopyRow()}
-                    </div>
-                    <p className="text-sm text-primary-600 font-medium">{insertLabel}</p>
-                  </div>
-
-                  <button
-                    type="button"
-                    onClick={handleDuplicate}
-                    disabled={processing}
-                    className="w-full bg-primary-600 text-white py-3 px-6 rounded-xl font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                  >
-                    {processing ? "Duplicating…" : `Duplicate Page ${selectedPage + 1} & Download`}
-                  </button>
-                </div>
+              {hasCopies && (
+                <button
+                  type="button"
+                  onClick={handleApply}
+                  disabled={processing}
+                  className="w-full bg-primary-600 text-white py-3 px-6 rounded-xl font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                >
+                  {processing ? "Duplicating…" : "Duplicate Pages & Download"}
+                </button>
               )}
             </>
           )}

--- a/src/tools/ReorderPages.tsx
+++ b/src/tools/ReorderPages.tsx
@@ -155,16 +155,14 @@ export default function ReorderPages() {
               setDragOverSlot(null);
             }}
             className={`shrink-0 pt-2 pr-2 flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none transition-all duration-200 ${
-              isSource
-                ? "ring-3 ring-primary-400 dark:ring-primary-500 rounded-xl scale-95 opacity-60 shadow-lg shadow-primary-200 dark:shadow-primary-900/40"
-                : "ring-0 scale-100 opacity-100"
+              isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"
             }`}
           >
             <div className="relative">
               <div
                 className={`w-20 sm:w-24 md:w-28 aspect-[3/4] bg-white dark:bg-dark-surface rounded-lg overflow-hidden border-2 transition-colors shadow-sm ${
                   isSource
-                    ? "border-primary-400 dark:border-primary-500"
+                    ? "border-dashed border-slate-300 dark:border-dark-border"
                     : "border-slate-200 dark:border-dark-border hover:border-primary-300 dark:hover:border-primary-600"
                 }`}
               >
@@ -175,7 +173,11 @@ export default function ReorderPages() {
                   draggable={false}
                 />
               </div>
-              <div className="absolute -top-1.5 -right-1.5 bg-primary-600 text-white text-xs font-bold w-6 h-6 rounded-full flex items-center justify-center shadow-md z-10">
+              <div
+                className={`absolute -top-1.5 -right-1.5 text-white text-xs font-bold w-6 h-6 rounded-full flex items-center justify-center shadow-md z-10 transition-opacity duration-200 ${
+                  isSource ? "bg-slate-400 dark:bg-slate-600 opacity-50" : "bg-primary-600"
+                }`}
+              >
                 {originalIndex + 1}
               </div>
             </div>
@@ -238,18 +240,15 @@ export default function ReorderPages() {
                       className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted dark:hover:text-dark-text transition-colors"
                     >
                       <svg
-                        className="w-3.5 h-3.5"
-                        viewBox="0 0 16 16"
+                        className="w-4 h-4"
+                        viewBox="0 0 24 24"
                         fill="none"
                         stroke="currentColor"
-                        strokeWidth="1.5"
+                        strokeWidth={2}
                         strokeLinecap="round"
                         strokeLinejoin="round"
                       >
-                        <path d="M2 8a6 6 0 0 1 10.2-4.3" />
-                        <path d="M14 8a6 6 0 0 1-10.2 4.3" />
-                        <polyline points="2 2 2 5.5 5.5 5.5" />
-                        <polyline points="14 14 14 10.5 10.5 10.5" />
+                        <path d="M3 10h10a5 5 0 0 1 5 5v2M3 10l4-4m-4 4l4 4" />
                       </svg>
                       Reset order
                     </button>

--- a/src/utils/pdf-operations.ts
+++ b/src/utils/pdf-operations.ts
@@ -923,6 +923,30 @@ export async function addBlankPage(file: File, position: number): Promise<Uint8A
 }
 
 /**
+ * Insert multiple blank pages into a PDF in a single pass.
+ *
+ * @param file - The source PDF file.
+ * @param positions - Sorted (ascending) array of 0-based insertion positions,
+ *   computed as if no blanks have been inserted yet.  Internally each position
+ *   is offset by the number of blanks already inserted so they land in the
+ *   correct spots.
+ * @returns New PDF bytes with all blank pages inserted.
+ */
+export async function addBlankPages(file: File, positions: number[]): Promise<Uint8Array> {
+  const arrayBuffer = await file.arrayBuffer();
+  const pdf = await PDFDocument.load(arrayBuffer);
+  const pageCount = pdf.getPageCount();
+  const { width, height } = pageCount > 0 ? pdf.getPage(0).getSize() : { width: 595, height: 842 };
+
+  // Sort ascending so each offset is simply the loop index.
+  const sorted = [...positions].sort((a, b) => a - b);
+  for (let i = 0; i < sorted.length; i++) {
+    pdf.insertPage(sorted[i] + i, [width, height]);
+  }
+  return pdf.save();
+}
+
+/**
  * Duplicate a page in a PDF and insert the copy at a target position.
  *
  * The source page is copied from a fresh load of the same file to avoid
@@ -946,6 +970,36 @@ export async function duplicatePage(
   const [copiedPage] = await result.copyPages(source, [sourceIndex]);
   result.insertPage(targetPosition, copiedPage);
   clonePageFormFields(result, targetPosition);
+  return result.save();
+}
+
+/**
+ * Duplicate multiple pages in a PDF in a single pass.
+ *
+ * @param file - The source PDF file.
+ * @param copies - Array of `{ sourceIndex, position }` objects where `position`
+ *   is the 0-based insertion index relative to the *original* page list (before
+ *   any copies are inserted).  Internally each position is offset by the number
+ *   of copies already inserted so they land in the correct spots.
+ * @returns New PDF bytes with all copies inserted.
+ */
+export async function duplicatePages(
+  file: File,
+  copies: { sourceIndex: number; position: number }[],
+): Promise<Uint8Array> {
+  const arrayBuffer = await file.arrayBuffer();
+  const source = await PDFDocument.load(arrayBuffer);
+  const result = await PDFDocument.load(arrayBuffer);
+
+  // Sort ascending by position so each offset is simply the loop index.
+  const sorted = [...copies].sort((a, b) => a.position - b.position);
+  for (let i = 0; i < sorted.length; i++) {
+    const { sourceIndex, position } = sorted[i];
+    const adjustedPosition = position + i;
+    const [copiedPage] = await result.copyPages(source, [sourceIndex]);
+    result.insertPage(adjustedPosition, copiedPage);
+    clonePageFormFields(result, adjustedPosition);
+  }
   return result.save();
 }
 


### PR DESCRIPTION
This pull request introduces significant improvements to the Add Blank Page and Duplicate Page tools, making both workflows more flexible and user-friendly. The changes enable users to add, reorder, and remove multiple blank or duplicate pages using a unified, drag-and-drop grid interface, rather than being limited to a single operation at a time. Additionally, the deployment is updated to support a custom domain, and dependencies are refreshed.

**Add Blank Page Tool Enhancements:**

* Refactored `AddBlankPage` to allow adding multiple blank pages, drag-and-drop reordering of all pages (original and blank), and batch insertion of blank pages at arbitrary positions. The UI now uses a wrapping grid layout and provides reset/add controls. (`src/tools/AddBlankPage.tsx`) [[1]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680L4-R34) [[2]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680L37-R47) [[3]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680L51-R245) [[4]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680L170-R255) [[5]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680L183-R268) [[6]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680L197-R352)

**Duplicate Page Tool Enhancements:**

* Refactored `DuplicatePage` to allow adding multiple copies of any page, drag-and-drop reordering of originals and copies, and batch duplication in a single operation. The UI now presents a unified grid for all pages and copies. (`src/tools/DuplicatePage.tsx`)

**Deployment and Configuration:**

* Set up a custom domain (`bytepdf.app`) for GitHub Pages by adding a `CNAME` file and updating the base path in the deployment workflow to `/`. (`public/CNAME`, `.github/workflows/deploy.yml`) [[1]](diffhunk://#diff-336c957969d046200f43c753dbdeeada1f0f815837778e433f168f3e823037cdR1) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L36-R39)

**Dependency Management:**

* Updated the `vite` dependency specifier to always use the latest version of `@voidzero-dev/vite-plus-core`. (`pnpm-lock.yaml`)