### PR TITLE
Enhance UI and functionality with improved styling and icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <h1>📄 BytePDF</h1>
   <p>A fast, modern, and privacy-focused PDF toolkit that runs entirely in your browser. No uploads, no servers, no tracking — your files never leave your device.
 
-🔗 **Try it here**: [https://sumitsahoo.github.io/bytepdf/](https://sumitsahoo.github.io/bytepdf/)
+🔗 **Try it here**: [http://bytepdf.app/](http://bytepdf.app/)
 
   </p>
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ _Protect your PDFs and manage metadata_
 | 🖥️ PDF Rendering    | [PDF.js](https://mozilla.github.io/pdf.js/)                    |
 | 🔤 Font Support     | [@pdf-lib/fontkit](https://github.com/Hopding/fontkit)         |
 | 🖱️ Drag & Drop      | [dnd-kit](https://dndkit.com/)                                 |
+| 🎯 Icons            | [Lucide React](https://lucide.dev/)                            |
 | 🔍 OCR Engine       | [Tesseract.js](https://tesseract.projectnaptha.com/)           |
 | 🗜️ ZIP Export       | [JSZip](https://stuk.github.io/jszip/)                         |
 | 📦 Toolchain CLI    | [Vite+ (`vp`)](https://viteplus.dev/)                          |

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@pdf-lib/fontkit": "^1.1.1",
     "jszip": "^3.10.1",
+    "lucide-react": "^1.7.0",
     "pdf-lib": "^1.17.1",
     "pdfjs-dist": "^5.6.205",
     "react": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
+      lucide-react:
+        specifier: ^1.7.0
+        version: 1.7.0(react@19.2.4)
       pdf-lib:
         specifier: ^1.17.1
         version: 1.17.1
@@ -1887,6 +1890,11 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react@1.7.0:
+    resolution: {integrity: sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
@@ -4213,6 +4221,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@1.7.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
 
   magic-string@0.25.9:
     dependencies:

--- a/public/icons/favicon.svg
+++ b/public/icons/favicon.svg
@@ -1,17 +1,86 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48" fill="none">
     <defs>
-        <linearGradient id="shld" x1="0" y1="0" x2="48" y2="48" gradientUnits="userSpaceOnUse">
-            <stop offset="0%" stop-color="#60A5FA" />
-            <stop offset="100%" stop-color="#1D4ED8" />
+        <!-- Ocean Blue Gradient -->
+        <linearGradient id="shieldGrad" x1="0" y1="4" x2="0" y2="44">
+            <stop offset="0%" stop-color="#3B82F6" />
+            <stop offset="100%" stop-color="#1E40AF" />
+        </linearGradient>
+
+        <!-- Subtle depth -->
+        <radialGradient id="innerGlow" cx="50%" cy="28%" r="75%">
+            <stop offset="0%" stop-color="#60A5FA" stop-opacity="0.22" />
+            <stop offset="100%" stop-color="#1E3A8A" stop-opacity="0" />
+        </radialGradient>
+
+        <!-- Document -->
+        <linearGradient id="docGrad" x1="16" y1="14" x2="34" y2="36">
+            <stop offset="0%" stop-color="#FFFFFF" />
+            <stop offset="100%" stop-color="#EFF4FF" />
+        </linearGradient>
+
+        <!-- Highlight -->
+        <linearGradient id="highlight" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.20" />
+            <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
         </linearGradient>
     </defs>
-    <!-- Shield shape -->
-    <path d="M24 2 L44 12 L44 28 Q44 42 24 47 Q4 42 4 28 L4 12 Z" fill="url(#shld)" />
-    <!-- Binary rows -->
-    <text x="24" y="18" font-family="ui-monospace,monospace" font-weight="700" font-size="8" fill="white" opacity="0.9"
-        text-anchor="middle">1 0 1</text>
-    <text x="24" y="28" font-family="ui-monospace,monospace" font-weight="700" font-size="8" fill="white" opacity="0.7"
-        text-anchor="middle">0 1 0</text>
-    <text x="24" y="38" font-family="ui-monospace,monospace" font-weight="700" font-size="8" fill="white" opacity="0.5"
-        text-anchor="middle">1 0 1</text>
+
+    <!-- OUTER SHIELD (reference geometry) -->
+    <path d="M24 2
+       L41 9.5
+       V25.5
+       C41 37 32.5 43 24 46
+       C15.5 43 7 37 7 25.5
+       V9.5
+       L24 2Z" fill="url(#shieldGrad)" stroke="rgba(255,255,255,0.10)" stroke-width="0.6" />
+
+    <!-- INNER GLOW -->
+    <path d="M24 2
+       L41 9.5
+       V25.5
+       C41 37 32.5 43 24 46
+       C15.5 43 7 37 7 25.5
+       V9.5
+       L24 2Z" fill="url(#innerGlow)" />
+
+    <!-- 🔥 TRUE INSET HIGHLIGHT (mathematically aligned) -->
+    <path d="M24 4.4
+       L38.6 10.9
+       V24.9
+       C38.6 34.2 31.8 39.6 24 42
+       V4.4Z" fill="url(#highlight)" />
+
+    <!-- DOCUMENT -->
+    <g>
+        <path d="M16 14
+         C16 13.4 16.4 13 17 13
+         H27.5
+         L32 17.5
+         V33
+         C32 33.6 31.6 34 31 34
+         H17
+         C16.4 34 16 33.6 16 33
+         V14Z" fill="url(#docGrad)" stroke="#DBEAFE" stroke-width="0.7" />
+
+        <!-- Fold -->
+        <path d="M27.5 13V17.5H32" fill="#DBEAFE" />
+    </g>
+
+    <!-- BINARY (perfect visual balance) -->
+    <g>
+        <!-- Row 1 -->
+        <circle cx="20" cy="21" r="1" fill="#1D4ED8" />
+        <circle cx="24" cy="21" r="1" fill="#93C5FD" />
+        <circle cx="28" cy="21" r="1" fill="#1D4ED8" />
+
+        <!-- Row 2 -->
+        <circle cx="20" cy="25" r="1" fill="#93C5FD" />
+        <circle cx="24" cy="25" r="1" fill="#1D4ED8" />
+        <circle cx="28" cy="25" r="1" fill="#93C5FD" />
+
+        <!-- Row 3 -->
+        <circle cx="20" cy="29" r="1" fill="#1D4ED8" />
+        <circle cx="24" cy="29" r="1" fill="#93C5FD" />
+        <circle cx="28" cy="29" r="1" fill="#1D4ED8" />
+    </g>
 </svg>

--- a/public/icons/logo.svg
+++ b/public/icons/logo.svg
@@ -1,17 +1,86 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 48 48" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="512" height="512" fill="none">
     <defs>
-        <linearGradient id="shld" x1="0" y1="0" x2="48" y2="48" gradientUnits="userSpaceOnUse">
-            <stop offset="0%" stop-color="#60A5FA" />
-            <stop offset="100%" stop-color="#1D4ED8" />
+        <!-- Ocean Blue Gradient -->
+        <linearGradient id="shieldGrad" x1="0" y1="4" x2="0" y2="44">
+            <stop offset="0%" stop-color="#3B82F6" />
+            <stop offset="100%" stop-color="#1E40AF" />
+        </linearGradient>
+
+        <!-- Subtle depth -->
+        <radialGradient id="innerGlow" cx="50%" cy="28%" r="75%">
+            <stop offset="0%" stop-color="#60A5FA" stop-opacity="0.22" />
+            <stop offset="100%" stop-color="#1E3A8A" stop-opacity="0" />
+        </radialGradient>
+
+        <!-- Document -->
+        <linearGradient id="docGrad" x1="16" y1="14" x2="34" y2="36">
+            <stop offset="0%" stop-color="#FFFFFF" />
+            <stop offset="100%" stop-color="#EFF4FF" />
+        </linearGradient>
+
+        <!-- Highlight -->
+        <linearGradient id="highlight" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#FFFFFF" stop-opacity="0.20" />
+            <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0" />
         </linearGradient>
     </defs>
-    <!-- Shield shape -->
-    <path d="M24 2 L44 12 L44 28 Q44 42 24 47 Q4 42 4 28 L4 12 Z" fill="url(#shld)" />
-    <!-- Binary rows -->
-    <text x="24" y="18" font-family="ui-monospace,monospace" font-weight="700" font-size="8" fill="white" opacity="0.9"
-        text-anchor="middle">1 0 1</text>
-    <text x="24" y="28" font-family="ui-monospace,monospace" font-weight="700" font-size="8" fill="white" opacity="0.7"
-        text-anchor="middle">0 1 0</text>
-    <text x="24" y="38" font-family="ui-monospace,monospace" font-weight="700" font-size="8" fill="white" opacity="0.5"
-        text-anchor="middle">1 0 1</text>
+
+    <!-- OUTER SHIELD (reference geometry) -->
+    <path d="M24 2
+       L41 9.5
+       V25.5
+       C41 37 32.5 43 24 46
+       C15.5 43 7 37 7 25.5
+       V9.5
+       L24 2Z" fill="url(#shieldGrad)" stroke="rgba(255,255,255,0.10)" stroke-width="0.6" />
+
+    <!-- INNER GLOW -->
+    <path d="M24 2
+       L41 9.5
+       V25.5
+       C41 37 32.5 43 24 46
+       C15.5 43 7 37 7 25.5
+       V9.5
+       L24 2Z" fill="url(#innerGlow)" />
+
+    <!-- 🔥 TRUE INSET HIGHLIGHT (mathematically aligned) -->
+    <path d="M24 4.4
+       L38.6 10.9
+       V24.9
+       C38.6 34.2 31.8 39.6 24 42
+       V4.4Z" fill="url(#highlight)" />
+
+    <!-- DOCUMENT -->
+    <g>
+        <path d="M16 14
+         C16 13.4 16.4 13 17 13
+         H27.5
+         L32 17.5
+         V33
+         C32 33.6 31.6 34 31 34
+         H17
+         C16.4 34 16 33.6 16 33
+         V14Z" fill="url(#docGrad)" stroke="#DBEAFE" stroke-width="0.7" />
+
+        <!-- Fold -->
+        <path d="M27.5 13V17.5H32" fill="#DBEAFE" />
+    </g>
+
+    <!-- BINARY (perfect visual balance) -->
+    <g>
+        <!-- Row 1 -->
+        <circle cx="20" cy="21" r="1" fill="#1D4ED8" />
+        <circle cx="24" cy="21" r="1" fill="#93C5FD" />
+        <circle cx="28" cy="21" r="1" fill="#1D4ED8" />
+
+        <!-- Row 2 -->
+        <circle cx="20" cy="25" r="1" fill="#93C5FD" />
+        <circle cx="24" cy="25" r="1" fill="#1D4ED8" />
+        <circle cx="28" cy="25" r="1" fill="#93C5FD" />
+
+        <!-- Row 3 -->
+        <circle cx="20" cy="29" r="1" fill="#1D4ED8" />
+        <circle cx="24" cy="29" r="1" fill="#93C5FD" />
+        <circle cx="28" cy="29" r="1" fill="#1D4ED8" />
+    </g>
 </svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@
 import { useState, useCallback, useMemo, useRef, useEffect, lazy, Suspense } from "react";
 import { Layout } from "./components/Layout.tsx";
 import { ToolCard } from "./components/ToolCard.tsx";
+import { Search, X } from "lucide-react";
 import type { Tool, ToolId } from "./types.ts";
 
 // ── Lazy-loaded tool components (code-split per tool) ────────────
@@ -454,19 +455,7 @@ function HomeScreen({ onSelectTool }: HomeScreenProps) {
       <div className="max-w-xl mx-auto mb-10">
         <div className="relative group">
           {/* Search icon */}
-          <svg
-            className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400 dark:text-dark-text-muted group-focus-within:text-primary-500 transition-colors duration-200"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-            />
-          </svg>
+          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400 dark:text-dark-text-muted group-focus-within:text-primary-500 transition-colors duration-200" />
 
           <input
             ref={searchInputRef}
@@ -489,14 +478,7 @@ function HomeScreen({ onSelectTool }: HomeScreenProps) {
                 className="p-1.5 rounded-lg hover:bg-slate-100 dark:hover:bg-dark-surface-alt text-slate-400 dark:text-dark-text-muted hover:text-slate-600 dark:hover:text-dark-text transition-colors"
                 aria-label="Clear search"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
+                <X className="w-4 h-4" />
               </button>
             ) : (
               <kbd className="hidden sm:inline-flex items-center gap-0.5 px-2 py-1 rounded-lg bg-slate-100 dark:bg-dark-surface-alt border border-slate-200 dark:border-dark-border text-xs text-slate-400 dark:text-dark-text-muted font-mono select-none">

--- a/src/components/FileDropZone.tsx
+++ b/src/components/FileDropZone.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useRef, useCallback } from "react";
+import { CloudUpload } from "lucide-react";
 
 interface FileDropZoneProps {
   /** MIME type filter for the hidden file input (e.g. ".pdf,application/pdf"). */
@@ -75,19 +76,10 @@ export function FileDropZone({
         onChange={handleChange}
         className="hidden"
       />
-      <svg
+      <CloudUpload
         className={`w-10 h-10 mx-auto mb-3 transition-colors ${isDragOver ? "text-primary-500" : "text-slate-400 dark:text-dark-text-muted"}`}
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-      >
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth={1.5}
-          d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
-        />
-      </svg>
+        strokeWidth={1.5}
+      />
       <p className="text-slate-600 dark:text-dark-text font-medium">{label}</p>
       {hint && <p className="text-sm text-slate-400 dark:text-dark-text-muted mt-1">{hint}</p>}
     </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useEffect, useRef, type ReactNode } from "react";
+import { ChevronLeft, Lock } from "lucide-react";
 
 interface LayoutProps {
   /** Content to render in the main area. */
@@ -46,14 +47,7 @@ export function Layout({ children, onHome, showBack }: LayoutProps) {
               className="p-2 -ml-2 rounded-lg hover:bg-slate-100 dark:hover:bg-dark-surface-alt transition-colors text-slate-600 dark:text-dark-text-muted"
               aria-label="Back to home"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
+              <ChevronLeft className="w-5 h-5" />
             </button>
           )}
           <button
@@ -126,17 +120,7 @@ export function Layout({ children, onHome, showBack }: LayoutProps) {
                 className="flex items-center justify-center gap-1.5 text-xs bg-primary-50 dark:bg-primary-900/40 text-primary-700 dark:text-primary-300 p-1.5 sm:px-2.5 sm:py-1 rounded-full sm:cursor-default"
                 aria-label="100% Private and Open Source"
               >
-                <svg
-                  className="w-4 h-4 sm:w-3 sm:h-3 shrink-0"
-                  fill="currentColor"
-                  viewBox="0 0 20 20"
-                >
-                  <path
-                    fillRule="evenodd"
-                    d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
-                    clipRule="evenodd"
-                  />
-                </svg>
+                <Lock className="w-4 h-4 sm:w-3 sm:h-3 shrink-0" />
                 <span className="hidden sm:inline whitespace-nowrap">100% Private</span>
                 <span className="hidden sm:inline text-primary-400 dark:text-primary-500">&</span>
                 <span className="hidden sm:inline whitespace-nowrap">Open Source</span>
@@ -155,8 +139,8 @@ export function Layout({ children, onHome, showBack }: LayoutProps) {
               className="p-1.5 rounded-full hover:bg-slate-100 dark:hover:bg-dark-surface-alt transition-colors text-slate-600 dark:text-dark-text-muted hover:text-slate-900 dark:hover:text-dark-text"
               aria-label="View source on GitHub"
             >
-              <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
               </svg>
             </a>
           </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -55,58 +55,7 @@ export function Layout({ children, onHome, showBack }: LayoutProps) {
             className="flex items-center gap-2.5 hover:opacity-80 transition-opacity"
           >
             <div className="w-12 h-12 flex items-center justify-center">
-              <svg className="w-12 h-12 drop-shadow-md" viewBox="0 0 48 48" fill="none">
-                <defs>
-                  <linearGradient
-                    id="shld"
-                    x1="0"
-                    y1="0"
-                    x2="48"
-                    y2="48"
-                    gradientUnits="userSpaceOnUse"
-                  >
-                    <stop offset="0%" stopColor="#60A5FA" />
-                    <stop offset="100%" stopColor="#1D4ED8" />
-                  </linearGradient>
-                </defs>
-                <path d="M24 2 L44 12 L44 28 Q44 42 24 47 Q4 42 4 28 L4 12 Z" fill="url(#shld)" />
-                <text
-                  x="24"
-                  y="18"
-                  fontFamily="ui-monospace,monospace"
-                  fontWeight="700"
-                  fontSize="8"
-                  fill="white"
-                  opacity="0.9"
-                  textAnchor="middle"
-                >
-                  1 0 1
-                </text>
-                <text
-                  x="24"
-                  y="28"
-                  fontFamily="ui-monospace,monospace"
-                  fontWeight="700"
-                  fontSize="8"
-                  fill="white"
-                  opacity="0.7"
-                  textAnchor="middle"
-                >
-                  0 1 0
-                </text>
-                <text
-                  x="24"
-                  y="38"
-                  fontFamily="ui-monospace,monospace"
-                  fontWeight="700"
-                  fontSize="8"
-                  fill="white"
-                  opacity="0.5"
-                  textAnchor="middle"
-                >
-                  1 0 1
-                </text>
-              </svg>
+              <img src="/icons/logo.svg" alt="BytePDF logo" className="w-12 h-12 drop-shadow-md" />
             </div>
             <span className="text-lg font-semibold text-slate-800 dark:text-dark-text">
               BytePDF

--- a/src/hooks/useSortableDrag.ts
+++ b/src/hooks/useSortableDrag.ts
@@ -1,0 +1,117 @@
+/**
+ * useSortableDrag — shared hook for page-reordering drag interactions.
+ *
+ * Supports both the HTML5 drag API (desktop) and touch events (mobile).
+ *
+ * Components must:
+ *  1. Spread `getTouchHandlers(slot)` onto every draggable item.
+ *  2. Add `data-drop-slot={slot}` to every drop-zone div so touch tracking
+ *     can identify the target slot via `document.elementFromPoint`.
+ *
+ * Touch behaviour:
+ *  - Drag activates after an 8 px movement threshold so short taps still
+ *    fire onClick (important for DuplicatePage).
+ *  - Once active, `touchmove` calls `preventDefault()` to stop the page
+ *    from scrolling — this requires the listener to be non-passive, which
+ *    is why it is registered on `document` rather than via JSX props.
+ */
+
+import { useState, useEffect, useRef, useCallback } from "react";
+
+export function useSortableDrag(onMove: (fromIndex: number, toSlot: number) => void) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
+
+  // Refs so the document-level listeners don't need to be re-registered
+  const touchStartSlot = useRef<number | null>(null);
+  const touchStartPos = useRef<{ x: number; y: number } | null>(null);
+  const isDragActive = useRef(false);
+  const onMoveRef = useRef(onMove);
+  onMoveRef.current = onMove;
+
+  /** Call this from each draggable item's onTouchStart. */
+  const getTouchHandlers = useCallback(
+    (slot: number) => ({
+      onTouchStart(e: React.TouchEvent) {
+        touchStartSlot.current = slot;
+        touchStartPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        isDragActive.current = false;
+      },
+    }),
+    [],
+  );
+
+  useEffect(() => {
+    const handleTouchMove = (e: TouchEvent) => {
+      if (touchStartSlot.current === null || touchStartPos.current === null) return;
+
+      const touch = e.touches[0];
+
+      // Activate drag only after the finger has moved at least 8 px.
+      if (!isDragActive.current) {
+        const dx = touch.clientX - touchStartPos.current.x;
+        const dy = touch.clientY - touchStartPos.current.y;
+        if (Math.sqrt(dx * dx + dy * dy) < 8) return;
+        isDragActive.current = true;
+        setDragIndex(touchStartSlot.current);
+      }
+
+      // Prevent page scroll while reordering.
+      e.preventDefault();
+
+      // Find which drop-zone slot is under the finger.
+      const el = document.elementFromPoint(touch.clientX, touch.clientY);
+      const zone = el?.closest("[data-drop-slot]") as HTMLElement | null;
+      if (zone) {
+        const slot = parseInt(zone.dataset.dropSlot!, 10);
+        const from = touchStartSlot.current!;
+        const isAdjacent = slot === from || slot === from + 1;
+        setDragOverSlot(isAdjacent ? null : slot);
+      } else {
+        setDragOverSlot(null);
+      }
+    };
+
+    const handleTouchEnd = (e: TouchEvent) => {
+      if (isDragActive.current && touchStartSlot.current !== null) {
+        const touch = e.changedTouches[0];
+        const el = document.elementFromPoint(touch.clientX, touch.clientY);
+        const zone = el?.closest("[data-drop-slot]") as HTMLElement | null;
+        if (zone) {
+          const slot = parseInt(zone.dataset.dropSlot!, 10);
+          const from = touchStartSlot.current;
+          const isAdjacent = slot === from || slot === from + 1;
+          if (!isAdjacent) {
+            onMoveRef.current(from, slot);
+          }
+        }
+      }
+      isDragActive.current = false;
+      touchStartSlot.current = null;
+      touchStartPos.current = null;
+      setDragIndex(null);
+      setDragOverSlot(null);
+    };
+
+    const handleTouchCancel = () => {
+      isDragActive.current = false;
+      touchStartSlot.current = null;
+      touchStartPos.current = null;
+      setDragIndex(null);
+      setDragOverSlot(null);
+    };
+
+    // Non-passive so we can call preventDefault() during active drag.
+    document.addEventListener("touchmove", handleTouchMove, { passive: false });
+    document.addEventListener("touchend", handleTouchEnd);
+    document.addEventListener("touchcancel", handleTouchCancel);
+
+    return () => {
+      document.removeEventListener("touchmove", handleTouchMove);
+      document.removeEventListener("touchend", handleTouchEnd);
+      document.removeEventListener("touchcancel", handleTouchCancel);
+    };
+  }, []); // all mutable state accessed via refs — no deps needed
+
+  return { dragIndex, dragOverSlot, setDragIndex, setDragOverSlot, getTouchHandlers };
+}

--- a/src/tools/AddBlankPage.tsx
+++ b/src/tools/AddBlankPage.tsx
@@ -9,6 +9,7 @@
 import { useState, useCallback } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
+import { useSortableDrag } from "../hooks/useSortableDrag.ts";
 import { addBlankPages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
 
@@ -29,9 +30,19 @@ export default function AddBlankPage() {
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Drag state
-  const [dragIndex, setDragIndex] = useState<number | null>(null);
-  const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
+  const handleMove = useCallback((fromIndex: number, toSlot: number) => {
+    setItems((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(fromIndex, 1);
+      const adjustedSlot = fromIndex < toSlot ? toSlot - 1 : toSlot;
+      next.splice(adjustedSlot, 0, moved);
+      return next;
+    });
+  }, []);
+
+  // Drag state (desktop + mobile touch)
+  const { dragIndex, dragOverSlot, setDragIndex, setDragOverSlot, getTouchHandlers } =
+    useSortableDrag(handleMove);
 
   const handleFile = useCallback(async (files: File[]) => {
     const pdf = files[0];
@@ -68,7 +79,7 @@ export default function AddBlankPage() {
     setItems((prev) => prev.filter((it) => it.type === "original"));
     setDragIndex(null);
     setDragOverSlot(null);
-  }, []);
+  }, [setDragIndex, setDragOverSlot]);
 
   const handleApply = useCallback(async () => {
     if (!file || !hasBlankPages) return;
@@ -106,6 +117,7 @@ export default function AddBlankPage() {
       elements.push(
         <div
           key={`drop-${slot}`}
+          data-drop-slot={slot}
           onDragOver={(e) => {
             if (isAdjacentToDrag) return;
             e.preventDefault();
@@ -168,6 +180,7 @@ export default function AddBlankPage() {
                 setDragIndex(null);
                 setDragOverSlot(null);
               }}
+              {...getTouchHandlers(slot)}
               className={`shrink-0 pt-2 pr-2 flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none transition-all duration-200 ${
                 isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"
               }`}
@@ -206,6 +219,7 @@ export default function AddBlankPage() {
                 setDragIndex(null);
                 setDragOverSlot(null);
               }}
+              {...getTouchHandlers(slot)}
               className={`shrink-0 pt-2 pr-2 flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none transition-all duration-200 ${
                 isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"
               }`}

--- a/src/tools/AddBlankPage.tsx
+++ b/src/tools/AddBlankPage.tsx
@@ -12,6 +12,7 @@ import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
 import { useSortableDrag } from "../hooks/useSortableDrag.ts";
 import { addBlankPages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
+import { Undo2, Plus } from "lucide-react";
 
 type BlankItem = { type: "blank"; id: string };
 type OriginalItem = { type: "original"; index: number };
@@ -307,17 +308,7 @@ export default function AddBlankPage() {
                         onClick={handleReset}
                         className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted dark:hover:text-dark-text transition-colors"
                       >
-                        <svg
-                          className="w-4 h-4"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth={2}
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <path d="M3 10h10a5 5 0 0 1 5 5v2M3 10l4-4m-4 4l4 4" />
-                        </svg>
+                        <Undo2 className="w-4 h-4" />
                         Reset
                       </button>
                     )}
@@ -326,17 +317,7 @@ export default function AddBlankPage() {
                       onClick={handleAddBlank}
                       className="inline-flex items-center gap-1.5 text-sm text-primary-600 hover:text-primary-700 font-medium transition-colors"
                     >
-                      <svg
-                        className="w-4 h-4"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="M12 5v14m-7-7h14" />
-                      </svg>
+                      <Plus className="w-4 h-4" />
                       Add blank page
                     </button>
                   </div>

--- a/src/tools/AddBookmarks.tsx
+++ b/src/tools/AddBookmarks.tsx
@@ -10,6 +10,7 @@ import { useState, useCallback, useEffect } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { addPdfBookmarks } from "../utils/pdf-operations.ts";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
+import { X, Plus } from "lucide-react";
 
 interface BookmarkEntry {
   id: number;
@@ -176,20 +177,7 @@ export default function AddBookmarks() {
                         className="w-8 h-8 flex items-center justify-center text-slate-400 hover:text-red-500 disabled:opacity-30 transition-colors rounded"
                         aria-label="Remove bookmark"
                       >
-                        <svg
-                          className="w-4 h-4"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                          aria-hidden="true"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M6 18L18 6M6 6l12 12"
-                          />
-                        </svg>
+                        <X className="w-4 h-4" aria-hidden="true" />
                       </button>
                     </div>
                   ))}
@@ -201,20 +189,7 @@ export default function AddBookmarks() {
                 onClick={addRow}
                 className="flex items-center gap-2 text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 font-medium"
               >
-                <svg
-                  className="w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 4v16m8-8H4"
-                  />
-                </svg>
+                <Plus className="w-4 h-4" aria-hidden="true" />
                 Add bookmark
               </button>
 

--- a/src/tools/AddPageNumbers.tsx
+++ b/src/tools/AddPageNumbers.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { Move, Hash } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { ColorPicker, hexToRgb, rgbToHex } from "../components/ColorPicker.tsx";
 import { addPageNumbers } from "../utils/pdf-operations.ts";
@@ -111,7 +112,8 @@ export default function AddPageNumbers() {
           <div className="space-y-5">
             {/* Position grid */}
             <div>
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+              <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                <Move className="w-3.5 h-3.5" />
                 Position
               </p>
               <div className="grid grid-cols-3 gap-2 max-w-[180px]">
@@ -134,7 +136,8 @@ export default function AddPageNumbers() {
 
             {/* Format */}
             <div>
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+              <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                <Hash className="w-3.5 h-3.5" />
                 Format
               </p>
               <div className="grid grid-cols-2 gap-2">

--- a/src/tools/AddPageNumbers.tsx
+++ b/src/tools/AddPageNumbers.tsx
@@ -111,19 +111,19 @@ export default function AddPageNumbers() {
           <div className="space-y-5">
             {/* Position grid */}
             <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-2">
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                 Position
-              </label>
+              </p>
               <div className="grid grid-cols-3 gap-2 max-w-[180px]">
                 {POSITIONS.map(({ value, label }) => (
                   <button
                     key={value}
                     onClick={() => setOpt("position", value)}
                     title={value.replace("-", " ")}
-                    className={`h-10 rounded-lg text-base font-bold border transition-colors ${
+                    className={`h-10 rounded-lg text-base font-bold border-2 transition-all duration-150 ${
                       options.position === value
-                        ? "bg-primary-600 text-white border-primary-600"
-                        : "border-slate-300 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:border-primary-400"
+                        ? "border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-300"
+                        : "border-slate-200 dark:border-dark-border text-slate-400 dark:text-dark-text-muted hover:border-slate-300 dark:hover:border-slate-500 bg-white dark:bg-dark-surface"
                     }`}
                   >
                     {label}
@@ -134,18 +134,18 @@ export default function AddPageNumbers() {
 
             {/* Format */}
             <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-2">
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                 Format
-              </label>
-              <div className="flex flex-wrap gap-2">
+              </p>
+              <div className="grid grid-cols-2 gap-2">
                 {FORMATS.map((f) => (
                   <button
                     key={f}
                     onClick={() => setOpt("format", f)}
-                    className={`px-3 py-1.5 rounded-lg text-sm font-medium border transition-colors ${
+                    className={`py-2 px-3 rounded-xl text-sm text-center border-2 transition-all duration-150 ${
                       options.format === f
-                        ? "bg-primary-600 text-white border-primary-600"
-                        : "border-slate-300 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:border-primary-400"
+                        ? "font-semibold border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 ring-1 ring-primary-300 dark:ring-primary-700"
+                        : "font-medium border-slate-200 dark:border-dark-border bg-white dark:bg-dark-surface text-slate-600 dark:text-dark-text-muted hover:border-slate-300 dark:hover:border-slate-500"
                     }`}
                   >
                     {f}
@@ -156,12 +156,12 @@ export default function AddPageNumbers() {
 
             <div className="grid grid-cols-2 gap-4">
               {/* Font size */}
-              <div>
-                <div className="flex justify-between mb-1.5">
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
                   <label className="text-sm font-medium text-slate-700 dark:text-dark-text">
                     Font size
                   </label>
-                  <span className="text-sm text-slate-500 dark:text-dark-text-muted">
+                  <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
                     {options.fontSize}pt
                   </span>
                 </div>
@@ -172,17 +172,17 @@ export default function AddPageNumbers() {
                   step={1}
                   value={options.fontSize}
                   onChange={(e) => setOpt("fontSize", Number(e.target.value))}
-                  className="w-full accent-primary-600"
+                  className="w-full accent-primary-600 cursor-pointer"
                 />
               </div>
 
               {/* Margin */}
-              <div>
-                <div className="flex justify-between mb-1.5">
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
                   <label className="text-sm font-medium text-slate-700 dark:text-dark-text">
                     Margin
                   </label>
-                  <span className="text-sm text-slate-500 dark:text-dark-text-muted">
+                  <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
                     {options.margin}pt
                   </span>
                 </div>
@@ -193,7 +193,7 @@ export default function AddPageNumbers() {
                   step={1}
                   value={options.margin}
                   onChange={(e) => setOpt("margin", Number(e.target.value))}
-                  className="w-full accent-primary-600"
+                  className="w-full accent-primary-600 cursor-pointer"
                 />
               </div>
             </div>

--- a/src/tools/AddSignature.tsx
+++ b/src/tools/AddSignature.tsx
@@ -17,6 +17,7 @@ import { ColorPicker, hexToRgb } from "../components/ColorPicker.tsx";
 import { addSignature } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
 import { downloadPdf } from "../utils/file-helpers.ts";
+import { PenLine, Upload, Move, Maximize2 } from "lucide-react";
 
 type SignatureMode = "draw" | "upload";
 
@@ -297,12 +298,13 @@ export default function AddSignature() {
                     setMode("draw");
                     setSignatureDataUrl("");
                   }}
-                  className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  className={`flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
                     mode === "draw"
                       ? "bg-white dark:bg-dark-surface text-slate-900 dark:text-dark-text shadow-sm"
                       : "text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text"
                   }`}
                 >
+                  <PenLine className="w-3.5 h-3.5" />
                   Draw
                 </button>
                 <button
@@ -310,12 +312,13 @@ export default function AddSignature() {
                     setMode("upload");
                     setSignatureDataUrl(uploadedImageUrl);
                   }}
-                  className={`px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                  className={`flex items-center gap-1.5 px-4 py-1.5 text-sm font-medium rounded-md transition-colors ${
                     mode === "upload"
                       ? "bg-white dark:bg-dark-surface text-slate-900 dark:text-dark-text shadow-sm"
                       : "text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text"
                   }`}
                 >
+                  <Upload className="w-3.5 h-3.5" />
                   Upload
                 </button>
               </div>
@@ -351,19 +354,7 @@ export default function AddSignature() {
                       onClick={() => uploadInputRef.current?.click()}
                       className="w-full flex flex-col items-center justify-center gap-2 py-8 border-2 border-dashed border-slate-300 dark:border-dark-border rounded-xl text-slate-500 dark:text-dark-text-muted hover:border-primary-400 hover:text-primary-600 transition-colors"
                     >
-                      <svg
-                        className="w-8 h-8"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                        strokeWidth={1.5}
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5"
-                        />
-                      </svg>
+                      <Upload className="w-8 h-8" strokeWidth={1.5} />
                       <span className="text-sm font-medium">Click to upload PNG or JPEG</span>
                       <span className="text-xs text-slate-400 dark:text-dark-text-muted">
                         Max 5 MB — transparent PNG recommended
@@ -420,7 +411,8 @@ export default function AddSignature() {
 
               {/* ---- Signature Size ---- */}
               <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-3">
-                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
+                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted flex items-center gap-1.5">
+                  <Maximize2 className="w-3.5 h-3.5" />
                   Signature Size
                 </p>
                 <div className="grid grid-cols-2 gap-3">
@@ -467,19 +459,7 @@ export default function AddSignature() {
 
               {signatureDataUrl && (
                 <div className="flex items-start gap-2 rounded-lg bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-800 px-3 py-2.5">
-                  <svg
-                    className="w-4 h-4 mt-0.5 text-primary-500 shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      d="M7 11.5V14m0 0v2.5m0-2.5h2.5M7 14H4.5m11-4L12 6.5m0 0L8.5 10M12 6.5V17"
-                    />
-                  </svg>
+                  <Move className="w-4 h-4 mt-0.5 text-primary-500 shrink-0" />
                   <p className="text-xs text-primary-700 dark:text-primary-300 leading-relaxed">
                     Drag the signature on the preview to reposition it
                   </p>

--- a/src/tools/AddSignature.tsx
+++ b/src/tools/AddSignature.tsx
@@ -419,28 +419,38 @@ export default function AddSignature() {
               )}
 
               {/* ---- Signature Size ---- */}
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5">
+              <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
                   Signature Size
-                </label>
+                </p>
                 <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="text-xs text-slate-500 dark:text-dark-text-muted">
-                      Width: {sigSize.width}px
-                    </label>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-slate-600 dark:text-dark-text-muted">
+                        Width
+                      </span>
+                      <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
+                        {sigSize.width}px
+                      </span>
+                    </div>
                     <input
                       type="range"
                       min={50}
                       max={400}
                       value={sigSize.width}
                       onChange={(e) => setSigSize((s) => ({ ...s, width: Number(e.target.value) }))}
-                      className="w-full accent-primary-600"
+                      className="w-full accent-primary-600 cursor-pointer"
                     />
                   </div>
-                  <div>
-                    <label className="text-xs text-slate-500 dark:text-dark-text-muted">
-                      Height: {sigSize.height}px
-                    </label>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-slate-600 dark:text-dark-text-muted">
+                        Height
+                      </span>
+                      <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
+                        {sigSize.height}px
+                      </span>
+                    </div>
                     <input
                       type="range"
                       min={20}
@@ -449,7 +459,7 @@ export default function AddSignature() {
                       onChange={(e) =>
                         setSigSize((s) => ({ ...s, height: Number(e.target.value) }))
                       }
-                      className="w-full accent-primary-600"
+                      className="w-full accent-primary-600 cursor-pointer"
                     />
                   </div>
                 </div>

--- a/src/tools/BatesNumbering.tsx
+++ b/src/tools/BatesNumbering.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { Move } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { ColorPicker, hexToRgb, rgbToHex } from "../components/ColorPicker.tsx";
 import { addBatesNumbers } from "../utils/pdf-operations.ts";
@@ -197,7 +198,8 @@ export default function BatesNumbering() {
 
             {/* Position grid */}
             <div>
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+              <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                <Move className="w-3.5 h-3.5" />
                 Position
               </p>
               <div className="grid grid-cols-3 gap-2 max-w-[180px]">

--- a/src/tools/BatesNumbering.tsx
+++ b/src/tools/BatesNumbering.tsx
@@ -116,8 +116,8 @@ export default function BatesNumbering() {
 
           {/* Live preview */}
           {pageCount > 0 && (
-            <div className="bg-slate-50 dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border p-4">
-              <p className="text-xs font-medium text-slate-500 dark:text-dark-text-muted mb-2">
+            <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4">
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                 Preview
               </p>
               <div className="flex items-center gap-3 text-sm font-mono">
@@ -197,19 +197,19 @@ export default function BatesNumbering() {
 
             {/* Position grid */}
             <div>
-              <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-2">
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                 Position
-              </label>
+              </p>
               <div className="grid grid-cols-3 gap-2 max-w-[180px]">
                 {POSITIONS.map(({ value, label }) => (
                   <button
                     key={value}
                     onClick={() => setOpt("position", value)}
                     title={value.replace("-", " ")}
-                    className={`h-10 rounded-lg text-base font-bold border transition-colors ${
+                    className={`h-10 rounded-lg text-base font-bold border-2 transition-all duration-150 ${
                       options.position === value
-                        ? "bg-primary-600 text-white border-primary-600"
-                        : "border-slate-300 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:border-primary-400"
+                        ? "border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-600 dark:text-primary-300"
+                        : "border-slate-200 dark:border-dark-border text-slate-400 dark:text-dark-text-muted hover:border-slate-300 dark:hover:border-slate-500 bg-white dark:bg-dark-surface"
                     }`}
                   >
                     {label}
@@ -220,12 +220,12 @@ export default function BatesNumbering() {
 
             <div className="grid grid-cols-2 gap-4">
               {/* Font size */}
-              <div>
-                <div className="flex justify-between mb-1.5">
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
                   <label className="text-sm font-medium text-slate-700 dark:text-dark-text">
                     Font size
                   </label>
-                  <span className="text-sm text-slate-500 dark:text-dark-text-muted">
+                  <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
                     {options.fontSize}pt
                   </span>
                 </div>
@@ -236,17 +236,17 @@ export default function BatesNumbering() {
                   step={1}
                   value={options.fontSize}
                   onChange={(e) => setOpt("fontSize", Number(e.target.value))}
-                  className="w-full accent-primary-600"
+                  className="w-full accent-primary-600 cursor-pointer"
                 />
               </div>
 
               {/* Margin */}
-              <div>
-                <div className="flex justify-between mb-1.5">
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
                   <label className="text-sm font-medium text-slate-700 dark:text-dark-text">
                     Margin
                   </label>
-                  <span className="text-sm text-slate-500 dark:text-dark-text-muted">
+                  <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
                     {options.margin}pt
                   </span>
                 </div>
@@ -257,7 +257,7 @@ export default function BatesNumbering() {
                   step={1}
                   value={options.margin}
                   onChange={(e) => setOpt("margin", Number(e.target.value))}
-                  className="w-full accent-primary-600"
+                  className="w-full accent-primary-600 cursor-pointer"
                 />
               </div>
             </div>

--- a/src/tools/CompressPdf.tsx
+++ b/src/tools/CompressPdf.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { Gauge } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { compressPdf } from "../utils/pdf-operations.ts";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
@@ -88,7 +89,8 @@ export default function CompressPdf() {
           {!result ? (
             <div className="space-y-4">
               <div>
-                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                  <Gauge className="w-3.5 h-3.5" />
                   Compression Level
                 </p>
                 <div className="grid grid-cols-3 gap-3">

--- a/src/tools/CompressPdf.tsx
+++ b/src/tools/CompressPdf.tsx
@@ -88,9 +88,9 @@ export default function CompressPdf() {
           {!result ? (
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-2">
+                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                   Compression Level
-                </label>
+                </p>
                 <div className="grid grid-cols-3 gap-3">
                   {[
                     {
@@ -112,10 +112,10 @@ export default function CompressPdf() {
                     <button
                       key={opt.value}
                       onClick={() => setQuality(opt.value)}
-                      className={`p-3 rounded-xl border-2 text-left transition-all ${
+                      className={`p-3 rounded-xl border-2 text-left transition-all duration-150 ${
                         quality === opt.value
-                          ? "border-primary-500 bg-primary-50 dark:bg-primary-900/40"
-                          : "border-slate-200 dark:border-dark-border hover:border-slate-300 dark:hover:border-slate-600"
+                          ? "border-primary-500 bg-primary-50 dark:bg-primary-900/30 ring-1 ring-primary-300 dark:ring-primary-700"
+                          : "border-slate-200 dark:border-dark-border bg-white dark:bg-dark-surface hover:border-slate-300 dark:hover:border-slate-500 hover:bg-slate-50 dark:hover:bg-dark-surface-alt"
                       }`}
                     >
                       <p
@@ -123,7 +123,7 @@ export default function CompressPdf() {
                       >
                         {opt.label}
                       </p>
-                      <p className="text-xs text-slate-500 dark:text-dark-text-muted mt-0.5">
+                      <p className="text-xs text-slate-500 dark:text-dark-text-muted mt-0.5 leading-snug">
                         {opt.desc}
                       </p>
                     </button>

--- a/src/tools/ContactSheet.tsx
+++ b/src/tools/ContactSheet.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { Grid3X3, Image, Tag } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { downloadBlob, formatFileSize } from "../utils/file-helpers.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
@@ -274,7 +275,8 @@ export default function ContactSheet() {
             <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-5">
               {/* Grid size */}
               <div>
-                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                  <Grid3X3 className="w-3.5 h-3.5" />
                   Grid Layout
                 </p>
                 <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
@@ -302,7 +304,8 @@ export default function ContactSheet() {
 
               {/* Output format */}
               <div>
-                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                  <Image className="w-3.5 h-3.5" />
                   Output Format
                 </p>
                 <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
@@ -324,7 +327,8 @@ export default function ContactSheet() {
 
               {/* Page labels toggle */}
               <div>
-                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                  <Tag className="w-3.5 h-3.5" />
                   Page Labels
                 </p>
                 <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">

--- a/src/tools/ContactSheet.tsx
+++ b/src/tools/ContactSheet.tsx
@@ -271,21 +271,21 @@ export default function ContactSheet() {
 
           <div className="grid md:grid-cols-2 gap-6 items-start">
             {/* Left column: controls */}
-            <div className="space-y-5">
+            <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-5">
               {/* Grid size */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5">
+                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                   Grid Layout
-                </label>
-                <div className="flex flex-wrap gap-2">
+                </p>
+                <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
                   {GRID_OPTIONS.map((opt) => (
                     <button
                       key={opt.value}
                       onClick={() => setGrid(opt.value)}
-                      className={`px-4 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                      className={`flex-1 rounded-lg py-1.5 px-3 text-sm transition-all duration-150 ${
                         grid === opt.value
-                          ? "bg-primary-600 text-white border-primary-600"
-                          : "border-slate-300 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:border-primary-400"
+                          ? "font-semibold text-white bg-primary-600 shadow-sm"
+                          : "font-medium text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text hover:bg-white/60 dark:hover:bg-dark-surface-alt"
                       }`}
                     >
                       {opt.label}
@@ -302,18 +302,18 @@ export default function ContactSheet() {
 
               {/* Output format */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5">
+                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                   Output Format
-                </label>
-                <div className="flex gap-2">
+                </p>
+                <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
                   {(["png", "pdf"] as const).map((f) => (
                     <button
                       key={f}
                       onClick={() => setOutput(f)}
-                      className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                      className={`flex-1 rounded-lg py-1.5 px-3 text-sm transition-all duration-150 ${
                         output === f
-                          ? "bg-primary-600 text-white border-primary-600"
-                          : "border-slate-300 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:border-primary-400"
+                          ? "font-semibold text-white bg-primary-600 shadow-sm"
+                          : "font-medium text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text hover:bg-white/60 dark:hover:bg-dark-surface-alt"
                       }`}
                     >
                       {f.toUpperCase()}
@@ -324,19 +324,24 @@ export default function ContactSheet() {
 
               {/* Page labels toggle */}
               <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5">
+                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                   Page Labels
-                </label>
-                <button
-                  onClick={() => setShowLabels(!showLabels)}
-                  className={`w-full py-2 rounded-lg text-sm font-medium border transition-colors ${
-                    showLabels
-                      ? "bg-primary-600 text-white border-primary-600"
-                      : "border-slate-300 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:border-primary-400"
-                  }`}
-                >
-                  {showLabels ? "Showing labels" : "Hidden"}
-                </button>
+                </p>
+                <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
+                  {([true, false] as const).map((val) => (
+                    <button
+                      key={String(val)}
+                      onClick={() => setShowLabels(val)}
+                      className={`flex-1 rounded-lg py-1.5 px-3 text-sm transition-all duration-150 ${
+                        showLabels === val
+                          ? "font-semibold text-white bg-primary-600 shadow-sm"
+                          : "font-medium text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text hover:bg-white/60 dark:hover:bg-dark-surface-alt"
+                      }`}
+                    >
+                      {val ? "Show labels" : "Hide labels"}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
 

--- a/src/tools/CropPages.tsx
+++ b/src/tools/CropPages.tsx
@@ -9,6 +9,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Check, Scissors } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { PageThumbnail } from "../components/PageThumbnail.tsx";
 import { cropPages, uncropPages } from "../utils/pdf-operations.ts";
@@ -202,7 +203,8 @@ export default function CropPages() {
               <div className="space-y-4">
                 <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-3">
                   <div className="flex items-center justify-between">
-                    <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
+                    <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
+                      <Scissors className="w-3.5 h-3.5" />
                       Margins to hide (mm)
                     </p>
                     {/* Mode toggle */}
@@ -422,16 +424,7 @@ export default function CropPages() {
                             selectedPages.has(i) ? (
                               <div className="bg-primary-500/20 inset-0 absolute flex items-center justify-center">
                                 <div className="w-5 h-5 bg-primary-500 rounded-full flex items-center justify-center">
-                                  <svg
-                                    viewBox="0 0 12 12"
-                                    className="w-3 h-3 text-white"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth={2}
-                                    aria-hidden="true"
-                                  >
-                                    <path d="M2 6l3 3 5-5" />
-                                  </svg>
+                                  <Check className="w-3 h-3 text-white" strokeWidth={3} />
                                 </div>
                               </div>
                             ) : null

--- a/src/tools/CropPages.tsx
+++ b/src/tools/CropPages.tsx
@@ -200,168 +200,170 @@ export default function CropPages() {
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {/* Left: controls */}
               <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <p className="text-sm font-medium text-slate-700 dark:text-dark-text">
-                    Margins to hide (mm)
-                  </p>
-                  {/* Mode toggle */}
-                  <div className="inline-flex rounded-lg border border-slate-200 dark:border-dark-border p-0.5 bg-slate-100 dark:bg-dark-surface-alt">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setMarginMode("uniform");
-                        setAllSides(0);
-                        setMargins({ top: 0, right: 0, bottom: 0, left: 0 });
-                      }}
-                      className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
-                        marginMode === "uniform"
-                          ? "bg-white dark:bg-dark-surface text-slate-900 dark:text-dark-text shadow-sm"
-                          : "text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text"
-                      }`}
-                    >
-                      All Sides
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setMarginMode("custom");
-                        setMargins({
-                          top: allSides,
-                          right: allSides,
-                          bottom: allSides,
-                          left: allSides,
-                        });
-                      }}
-                      className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
-                        marginMode === "custom"
-                          ? "bg-white dark:bg-dark-surface text-slate-900 dark:text-dark-text shadow-sm"
-                          : "text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text"
-                      }`}
-                    >
-                      Custom
-                    </button>
-                  </div>
-                </div>
-
-                {/* Uniform input */}
-                {marginMode === "uniform" && (
-                  <div>
-                    <label
-                      htmlFor="crop-all"
-                      className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
-                    >
-                      <span>All sides</span>
-                      <span>{allSides} mm</span>
-                    </label>
-                    <input
-                      id="crop-all"
-                      type="number"
-                      min={0}
-                      step={1}
-                      value={allSides}
-                      onChange={(e) => setUniformMargin(Number(e.target.value))}
-                      className={inputClass}
-                    />
-                  </div>
-                )}
-
-                {/* Custom inputs */}
-                {marginMode === "custom" && (
-                  <>
-                    {/* Top */}
-                    <div>
-                      <label
-                        htmlFor="crop-top"
-                        className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
-                      >
-                        <span>Top</span>
-                        <span>{margins.top} mm</span>
-                      </label>
-                      <input
-                        id="crop-top"
-                        type="number"
-                        min={0}
-                        step={1}
-                        value={margins.top}
-                        onChange={(e) => setMargin("top", Number(e.target.value))}
-                        className={inputClass}
-                      />
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-3">
-                      {/* Left */}
-                      <div>
-                        <label
-                          htmlFor="crop-left"
-                          className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
-                        >
-                          <span>Left</span>
-                          <span>{margins.left} mm</span>
-                        </label>
-                        <input
-                          id="crop-left"
-                          type="number"
-                          min={0}
-                          step={1}
-                          value={margins.left}
-                          onChange={(e) => setMargin("left", Number(e.target.value))}
-                          className={inputClass}
-                        />
-                      </div>
-                      {/* Right */}
-                      <div>
-                        <label
-                          htmlFor="crop-right"
-                          className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
-                        >
-                          <span>Right</span>
-                          <span>{margins.right} mm</span>
-                        </label>
-                        <input
-                          id="crop-right"
-                          type="number"
-                          min={0}
-                          step={1}
-                          value={margins.right}
-                          onChange={(e) => setMargin("right", Number(e.target.value))}
-                          className={inputClass}
-                        />
-                      </div>
-                    </div>
-
-                    {/* Bottom */}
-                    <div>
-                      <label
-                        htmlFor="crop-bottom"
-                        className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
-                      >
-                        <span>Bottom</span>
-                        <span>{margins.bottom} mm</span>
-                      </label>
-                      <input
-                        id="crop-bottom"
-                        type="number"
-                        min={0}
-                        step={1}
-                        value={margins.bottom}
-                        onChange={(e) => setMargin("bottom", Number(e.target.value))}
-                        className={inputClass}
-                      />
-                    </div>
-                  </>
-                )}
-
-                {!marginsValid &&
-                  (margins.top > 0 ||
-                    margins.right > 0 ||
-                    margins.bottom > 0 ||
-                    margins.left > 0) && (
-                    <p className="text-sm text-red-500">
-                      Margins exceed page dimensions — reduce them.
+                <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
+                      Margins to hide (mm)
                     </p>
+                    {/* Mode toggle */}
+                    <div className="inline-flex rounded-lg border border-slate-200 dark:border-dark-border p-0.5 bg-slate-100 dark:bg-dark-surface-alt">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setMarginMode("uniform");
+                          setAllSides(0);
+                          setMargins({ top: 0, right: 0, bottom: 0, left: 0 });
+                        }}
+                        className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                          marginMode === "uniform"
+                            ? "bg-white dark:bg-dark-surface text-slate-900 dark:text-dark-text shadow-sm"
+                            : "text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text"
+                        }`}
+                      >
+                        All Sides
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setMarginMode("custom");
+                          setMargins({
+                            top: allSides,
+                            right: allSides,
+                            bottom: allSides,
+                            left: allSides,
+                          });
+                        }}
+                        className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
+                          marginMode === "custom"
+                            ? "bg-white dark:bg-dark-surface text-slate-900 dark:text-dark-text shadow-sm"
+                            : "text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text"
+                        }`}
+                      >
+                        Custom
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Uniform input */}
+                  {marginMode === "uniform" && (
+                    <div>
+                      <label
+                        htmlFor="crop-all"
+                        className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
+                      >
+                        <span>All sides</span>
+                        <span>{allSides} mm</span>
+                      </label>
+                      <input
+                        id="crop-all"
+                        type="number"
+                        min={0}
+                        step={1}
+                        value={allSides}
+                        onChange={(e) => setUniformMargin(Number(e.target.value))}
+                        className={inputClass}
+                      />
+                    </div>
                   )}
 
-                <div className="bg-slate-50 dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border p-3 space-y-1">
+                  {/* Custom inputs */}
+                  {marginMode === "custom" && (
+                    <>
+                      {/* Top */}
+                      <div>
+                        <label
+                          htmlFor="crop-top"
+                          className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
+                        >
+                          <span>Top</span>
+                          <span>{margins.top} mm</span>
+                        </label>
+                        <input
+                          id="crop-top"
+                          type="number"
+                          min={0}
+                          step={1}
+                          value={margins.top}
+                          onChange={(e) => setMargin("top", Number(e.target.value))}
+                          className={inputClass}
+                        />
+                      </div>
+
+                      <div className="grid grid-cols-2 gap-3">
+                        {/* Left */}
+                        <div>
+                          <label
+                            htmlFor="crop-left"
+                            className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
+                          >
+                            <span>Left</span>
+                            <span>{margins.left} mm</span>
+                          </label>
+                          <input
+                            id="crop-left"
+                            type="number"
+                            min={0}
+                            step={1}
+                            value={margins.left}
+                            onChange={(e) => setMargin("left", Number(e.target.value))}
+                            className={inputClass}
+                          />
+                        </div>
+                        {/* Right */}
+                        <div>
+                          <label
+                            htmlFor="crop-right"
+                            className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
+                          >
+                            <span>Right</span>
+                            <span>{margins.right} mm</span>
+                          </label>
+                          <input
+                            id="crop-right"
+                            type="number"
+                            min={0}
+                            step={1}
+                            value={margins.right}
+                            onChange={(e) => setMargin("right", Number(e.target.value))}
+                            className={inputClass}
+                          />
+                        </div>
+                      </div>
+
+                      {/* Bottom */}
+                      <div>
+                        <label
+                          htmlFor="crop-bottom"
+                          className="flex justify-between text-sm text-slate-600 dark:text-dark-text-muted mb-1"
+                        >
+                          <span>Bottom</span>
+                          <span>{margins.bottom} mm</span>
+                        </label>
+                        <input
+                          id="crop-bottom"
+                          type="number"
+                          min={0}
+                          step={1}
+                          value={margins.bottom}
+                          onChange={(e) => setMargin("bottom", Number(e.target.value))}
+                          className={inputClass}
+                        />
+                      </div>
+                    </>
+                  )}
+
+                  {!marginsValid &&
+                    (margins.top > 0 ||
+                      margins.right > 0 ||
+                      margins.bottom > 0 ||
+                      margins.left > 0) && (
+                      <p className="text-sm text-red-500">
+                        Margins exceed page dimensions — reduce them.
+                      </p>
+                    )}
+                </div>
+
+                <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-3 space-y-1">
                   <p className="text-xs text-slate-500 dark:text-dark-text-muted">
                     <strong>Crop</strong> sets a crop box that hides margins from view without
                     permanently removing them — the hidden content stays in the file.

--- a/src/tools/DeletePages.tsx
+++ b/src/tools/DeletePages.tsx
@@ -10,6 +10,7 @@ import { useState, useCallback } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { PageThumbnail } from "../components/PageThumbnail.tsx";
 import { deletePages } from "../utils/pdf-operations.ts";
+import { Trash2 } from "lucide-react";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
 import { downloadPdf } from "../utils/file-helpers.ts";
 
@@ -118,19 +119,7 @@ export default function DeletePages() {
                   overlay={
                     selectedPages.has(i) ? (
                       <div className="bg-red-500/70 inset-0 absolute flex items-center justify-center">
-                        <svg
-                          className="w-8 h-8 text-white"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                          />
-                        </svg>
+                        <Trash2 className="w-8 h-8 text-white" />
                       </div>
                     ) : null
                   }

--- a/src/tools/DuplicatePage.tsx
+++ b/src/tools/DuplicatePage.tsx
@@ -12,6 +12,7 @@ import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
 import { useSortableDrag } from "../hooks/useSortableDrag.ts";
 import { duplicatePages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
+import { Undo2 } from "lucide-react";
 
 type CopyItem = { type: "copy"; sourceIndex: number; id: string };
 type OriginalItem = { type: "original"; index: number };
@@ -321,17 +322,7 @@ export default function DuplicatePage() {
                       onClick={handleReset}
                       className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted dark:hover:text-dark-text transition-colors"
                     >
-                      <svg
-                        className="w-4 h-4"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="M3 10h10a5 5 0 0 1 5 5v2M3 10l4-4m-4 4l4 4" />
-                      </svg>
+                      <Undo2 className="w-4 h-4" />
                       Reset
                     </button>
                   )}

--- a/src/tools/DuplicatePage.tsx
+++ b/src/tools/DuplicatePage.tsx
@@ -58,8 +58,12 @@ export default function DuplicatePage() {
   const hasCopies = items.some((it) => it.type === "copy");
   const isDragging = dragIndex !== null;
 
-  const handleDuplicatePage = useCallback((pageIndex: number) => {
-    setItems((prev) => [{ type: "copy", sourceIndex: pageIndex, id: nextCopyId() }, ...prev]);
+  const handleDuplicatePage = useCallback((pageIndex: number, afterSlot: number) => {
+    setItems((prev) => {
+      const next = [...prev];
+      next.splice(afterSlot + 1, 0, { type: "copy", sourceIndex: pageIndex, id: nextCopyId() });
+      return next;
+    });
   }, []);
 
   const handleReset = useCallback(() => {
@@ -204,7 +208,7 @@ export default function DuplicatePage() {
               key={`page-${item.index}`}
               draggable={hasCopies}
               onClick={() => {
-                if (!isDragging) handleDuplicatePage(item.index);
+                if (!isDragging) handleDuplicatePage(item.index, slot);
               }}
               onDragStart={(e) => {
                 if (!hasCopies) return;
@@ -261,7 +265,7 @@ export default function DuplicatePage() {
           accept=".pdf,application/pdf"
           onFiles={handleFile}
           label="Drop a PDF file here"
-          hint="Click pages to duplicate them, then drag copies to position them"
+          hint="Click a page to duplicate it right after — drag copies to rearrange"
         />
       ) : (
         <>
@@ -294,8 +298,8 @@ export default function DuplicatePage() {
                     {isDragging
                       ? "Drop at the desired position"
                       : hasCopies
-                        ? "Click a page to add another copy, or drag to rearrange"
-                        : "Click a page to duplicate it"}
+                        ? "Click a page to add another copy — drag to rearrange"
+                        : "Click a page to duplicate it — the copy appears right after"}
                   </p>
                   {hasCopies && (
                     <button

--- a/src/tools/DuplicatePage.tsx
+++ b/src/tools/DuplicatePage.tsx
@@ -9,6 +9,7 @@
 import { useCallback, useState } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
+import { useSortableDrag } from "../hooks/useSortableDrag.ts";
 import { duplicatePages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
 
@@ -29,9 +30,19 @@ export default function DuplicatePage() {
   const [processing, setProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Drag state
-  const [dragIndex, setDragIndex] = useState<number | null>(null);
-  const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
+  const handleMove = useCallback((fromIndex: number, toSlot: number) => {
+    setItems((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(fromIndex, 1);
+      const adjustedSlot = fromIndex < toSlot ? toSlot - 1 : toSlot;
+      next.splice(adjustedSlot, 0, moved);
+      return next;
+    });
+  }, []);
+
+  // Drag state (desktop + mobile touch)
+  const { dragIndex, dragOverSlot, setDragIndex, setDragOverSlot, getTouchHandlers } =
+    useSortableDrag(handleMove);
 
   const handleFile = useCallback(async (files: File[]) => {
     const pdf = files[0];
@@ -70,7 +81,7 @@ export default function DuplicatePage() {
     setItems((prev) => prev.filter((it) => it.type === "original"));
     setDragIndex(null);
     setDragOverSlot(null);
-  }, []);
+  }, [setDragIndex, setDragOverSlot]);
 
   const handleApply = useCallback(async () => {
     if (!file || !hasCopies) return;
@@ -107,6 +118,7 @@ export default function DuplicatePage() {
       elements.push(
         <div
           key={`drop-${slot}`}
+          data-drop-slot={slot}
           onDragOver={(e) => {
             if (isAdjacentToDrag) return;
             e.preventDefault();
@@ -169,6 +181,7 @@ export default function DuplicatePage() {
                 setDragIndex(null);
                 setDragOverSlot(null);
               }}
+              {...getTouchHandlers(slot)}
               className={`shrink-0 p-2 flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none transition-all duration-200 ${
                 isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"
               }`}
@@ -219,6 +232,7 @@ export default function DuplicatePage() {
                 setDragIndex(null);
                 setDragOverSlot(null);
               }}
+              {...(hasCopies ? getTouchHandlers(slot) : {})}
               className={`shrink-0 p-2 flex flex-col items-center gap-1.5 select-none transition-all duration-200 cursor-pointer ${
                 hasCopies ? "active:cursor-grabbing" : "hover:scale-105"
               } ${isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"}`}

--- a/src/tools/ExtractPages.tsx
+++ b/src/tools/ExtractPages.tsx
@@ -13,6 +13,7 @@ import { PageThumbnail } from "../components/PageThumbnail.tsx";
 import { extractPages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
 import { downloadPdf } from "../utils/file-helpers.ts";
+import { Check } from "lucide-react";
 
 /** Parse a range string like "1-3, 5, 7-9" into sorted, unique 0-based page indices. */
 function parseRangeInput(input: string, pageCount: number): number[] {
@@ -194,19 +195,7 @@ export default function ExtractPages() {
                     selectedPages.has(i) ? (
                       <div className="bg-primary-600/20 inset-0 absolute flex items-center justify-center">
                         <div className="w-6 h-6 rounded-full bg-primary-600 flex items-center justify-center shadow">
-                          <svg
-                            className="w-3.5 h-3.5 text-white"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={3}
-                              d="M5 13l4 4L19 7"
-                            />
-                          </svg>
+                          <Check className="w-3.5 h-3.5 text-white" strokeWidth={3} />
                         </div>
                       </div>
                     ) : null

--- a/src/tools/FillPdfForm.tsx
+++ b/src/tools/FillPdfForm.tsx
@@ -17,6 +17,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { ChevronDown } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { fillPdfForm, getFieldPageIndices } from "../utils/pdf-operations.ts";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
@@ -357,18 +358,7 @@ export default function FillPdfForm() {
                                 ))}
                               </select>
                               <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3 text-slate-400 dark:text-dark-text-muted">
-                                <svg
-                                  className="w-4 h-4"
-                                  viewBox="0 0 16 16"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  strokeWidth="1.75"
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                  aria-hidden="true"
-                                >
-                                  <path d="M4 6l4 4 4-4" />
-                                </svg>
+                                <ChevronDown className="w-4 h-4" />
                               </div>
                             </div>
                           )}

--- a/src/tools/HeaderFooter.tsx
+++ b/src/tools/HeaderFooter.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { PanelTop, PanelBottom } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { ColorPicker, hexToRgb, rgbToHex } from "../components/ColorPicker.tsx";
 import { addHeaderFooter } from "../utils/pdf-operations.ts";
@@ -97,7 +98,8 @@ export default function HeaderFooter() {
           <div className="space-y-4">
             {/* Header row */}
             <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
+              <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
+                <PanelTop className="w-3.5 h-3.5" />
                 Header
               </p>
               <div className="grid grid-cols-3 gap-2">
@@ -127,7 +129,8 @@ export default function HeaderFooter() {
 
             {/* Footer row */}
             <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
+              <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
+                <PanelBottom className="w-3.5 h-3.5" />
                 Footer
               </p>
               <div className="grid grid-cols-3 gap-2">

--- a/src/tools/HeaderFooter.tsx
+++ b/src/tools/HeaderFooter.tsx
@@ -96,8 +96,8 @@ export default function HeaderFooter() {
 
           <div className="space-y-4">
             {/* Header row */}
-            <div className="bg-slate-50 dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border p-4 space-y-2">
-              <p className="text-xs font-semibold text-slate-500 dark:text-dark-text-muted uppercase tracking-wide">
+            <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
                 Header
               </p>
               <div className="grid grid-cols-3 gap-2">
@@ -126,8 +126,8 @@ export default function HeaderFooter() {
             </div>
 
             {/* Footer row */}
-            <div className="bg-slate-50 dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border p-4 space-y-2">
-              <p className="text-xs font-semibold text-slate-500 dark:text-dark-text-muted uppercase tracking-wide">
+            <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted">
                 Footer
               </p>
               <div className="grid grid-cols-3 gap-2">
@@ -167,12 +167,12 @@ export default function HeaderFooter() {
 
             <div className="grid grid-cols-2 gap-4">
               {/* Font size */}
-              <div>
-                <div className="flex justify-between mb-1.5">
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
                   <label className="text-sm font-medium text-slate-700 dark:text-dark-text">
                     Font size
                   </label>
-                  <span className="text-sm text-slate-500 dark:text-dark-text-muted">
+                  <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
                     {options.fontSize}pt
                   </span>
                 </div>
@@ -183,17 +183,17 @@ export default function HeaderFooter() {
                   step={1}
                   value={options.fontSize}
                   onChange={(e) => setOpt("fontSize", Number(e.target.value))}
-                  className="w-full accent-primary-600"
+                  className="w-full accent-primary-600 cursor-pointer"
                 />
               </div>
 
               {/* Margin */}
-              <div>
-                <div className="flex justify-between mb-1.5">
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
                   <label className="text-sm font-medium text-slate-700 dark:text-dark-text">
                     Margin
                   </label>
-                  <span className="text-sm text-slate-500 dark:text-dark-text-muted">
+                  <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
                     {options.margin}pt
                   </span>
                 </div>
@@ -204,7 +204,7 @@ export default function HeaderFooter() {
                   step={1}
                   value={options.margin}
                   onChange={(e) => setOpt("margin", Number(e.target.value))}
-                  className="w-full accent-primary-600"
+                  className="w-full accent-primary-600 cursor-pointer"
                 />
               </div>
             </div>
@@ -224,18 +224,18 @@ export default function HeaderFooter() {
             </div>
 
             {/* Skip first page */}
-            <label className="flex items-center gap-3 cursor-pointer">
+            <label className="flex items-start gap-3 cursor-pointer select-none">
               <input
                 type="checkbox"
                 checked={options.skipFirstPage}
                 onChange={(e) => setOpt("skipFirstPage", e.target.checked)}
-                className="w-4 h-4 text-primary-600 rounded"
+                className="mt-0.5 h-4 w-4 shrink-0 rounded accent-primary-600 cursor-pointer"
               />
-              <div>
-                <p className="text-sm font-medium text-slate-700 dark:text-dark-text">
+              <div className="flex flex-col gap-0.5">
+                <p className="text-sm font-medium text-slate-700 dark:text-dark-text leading-snug">
                   Skip first page
                 </p>
-                <p className="text-xs text-slate-400 dark:text-dark-text-muted">
+                <p className="text-xs text-slate-400 dark:text-dark-text-muted leading-snug">
                   Useful when the first page is a cover or title page
                 </p>
               </div>

--- a/src/tools/ImagesToPdf.tsx
+++ b/src/tools/ImagesToPdf.tsx
@@ -11,6 +11,7 @@ import { useState, useCallback, useEffect } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { imagesToPdf } from "../utils/pdf-operations.ts";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
+import { ChevronUp, ChevronDown, X } from "lucide-react";
 
 /** Internal representation of a queued image with its preview URL. */
 interface ImageItem {
@@ -142,19 +143,7 @@ export default function ImagesToPdf() {
                     className="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-dark-surface-alt disabled:opacity-30 transition-colors"
                     aria-label="Move up"
                   >
-                    <svg
-                      className="w-4 h-4 text-slate-500 dark:text-dark-text-muted"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M5 15l7-7 7 7"
-                      />
-                    </svg>
+                    <ChevronUp className="w-4 h-4 text-slate-500 dark:text-dark-text-muted" />
                   </button>
                   <button
                     onClick={() => moveImage(index, 1)}
@@ -162,38 +151,14 @@ export default function ImagesToPdf() {
                     className="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-dark-surface-alt disabled:opacity-30 transition-colors"
                     aria-label="Move down"
                   >
-                    <svg
-                      className="w-4 h-4 text-slate-500 dark:text-dark-text-muted"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M19 9l-7 7-7-7"
-                      />
-                    </svg>
+                    <ChevronDown className="w-4 h-4 text-slate-500 dark:text-dark-text-muted" />
                   </button>
                   <button
                     onClick={() => removeImage(item.id)}
                     className="p-1.5 rounded hover:bg-red-50 transition-colors"
                     aria-label="Remove"
                   >
-                    <svg
-                      className="w-4 h-4 text-slate-400 dark:text-dark-text-muted hover:text-red-500"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
+                    <X className="w-4 h-4 text-slate-400 dark:text-dark-text-muted hover:text-red-500" />
                   </button>
                 </div>
               </div>

--- a/src/tools/ImagesToPdf.tsx
+++ b/src/tools/ImagesToPdf.tsx
@@ -96,18 +96,18 @@ export default function ImagesToPdf() {
       {images.length > 0 && (
         <>
           <div>
-            <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-2">
+            <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
               Page Size
-            </label>
-            <div className="flex gap-2">
+            </p>
+            <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
               {(["a4", "letter", "fit"] as const).map((size) => (
                 <button
                   key={size}
                   onClick={() => setPageSize(size)}
-                  className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  className={`flex-1 rounded-lg py-1.5 px-3 text-sm transition-all duration-150 ${
                     pageSize === size
-                      ? "bg-primary-600 text-white"
-                      : "bg-slate-100 dark:bg-dark-surface-alt text-slate-700 dark:text-dark-text hover:bg-slate-200 dark:hover:bg-dark-border"
+                      ? "font-semibold text-white bg-primary-600 shadow-sm"
+                      : "font-medium text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text hover:bg-white/60 dark:hover:bg-dark-surface-alt"
                   }`}
                 >
                   {size === "a4" ? "A4" : size === "letter" ? "Letter" : "Fit to Image"}

--- a/src/tools/MergePdf.tsx
+++ b/src/tools/MergePdf.tsx
@@ -10,6 +10,7 @@ import { useState, useCallback } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { mergePdfs } from "../utils/pdf-operations.ts";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
+import { ChevronUp, ChevronDown, X } from "lucide-react";
 
 /** Internal representation of a queued PDF file. */
 interface FileItem {
@@ -94,19 +95,7 @@ export default function MergePdf() {
                   className="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-dark-surface-alt disabled:opacity-30 transition-colors"
                   aria-label="Move up"
                 >
-                  <svg
-                    className="w-4 h-4 text-slate-500 dark:text-dark-text-muted"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M5 15l7-7 7 7"
-                    />
-                  </svg>
+                  <ChevronUp className="w-4 h-4 text-slate-500 dark:text-dark-text-muted" />
                 </button>
                 <button
                   onClick={() => moveFile(index, 1)}
@@ -114,38 +103,14 @@ export default function MergePdf() {
                   className="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-dark-surface-alt disabled:opacity-30 transition-colors"
                   aria-label="Move down"
                 >
-                  <svg
-                    className="w-4 h-4 text-slate-500 dark:text-dark-text-muted"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M19 9l-7 7-7-7"
-                    />
-                  </svg>
+                  <ChevronDown className="w-4 h-4 text-slate-500 dark:text-dark-text-muted" />
                 </button>
                 <button
                   onClick={() => removeFile(item.id)}
                   className="p-1.5 rounded hover:bg-red-50 transition-colors"
                   aria-label="Remove file"
                 >
-                  <svg
-                    className="w-4 h-4 text-slate-400 dark:text-dark-text-muted hover:text-red-500"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
+                  <X className="w-4 h-4 text-slate-400 dark:text-dark-text-muted hover:text-red-500" />
                 </button>
               </div>
             </div>

--- a/src/tools/NupPages.tsx
+++ b/src/tools/NupPages.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { LayoutGrid } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { nupPages } from "../utils/pdf-operations.ts";
 import { getPageCount } from "../utils/pdf-renderer.ts";
@@ -115,7 +116,8 @@ export default function NupPages() {
             <>
               {/* Layout selector */}
               <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4">
-                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-3">
+                <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-3">
+                  <LayoutGrid className="w-3.5 h-3.5" />
                   Layout
                 </p>
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">

--- a/src/tools/NupPages.tsx
+++ b/src/tools/NupPages.tsx
@@ -114,19 +114,19 @@ export default function NupPages() {
           ) : (
             <>
               {/* Layout selector */}
-              <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border p-4">
-                <p className="text-sm font-medium text-slate-700 dark:text-dark-text mb-3">
-                  Choose layout
+              <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4">
+                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-3">
+                  Layout
                 </p>
                 <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                   {LAYOUTS.map((l) => (
                     <button
                       key={l.value}
                       onClick={() => setLayout(l.value)}
-                      className={`border rounded-lg p-3 text-center transition-colors ${
+                      className={`border-2 rounded-xl p-3 text-center transition-all duration-150 ${
                         layout === l.value
-                          ? "border-primary-500 bg-primary-50 dark:bg-primary-900/20"
-                          : "border-slate-200 dark:border-dark-border hover:border-slate-300 dark:hover:border-slate-500"
+                          ? "border-primary-500 bg-primary-50 dark:bg-primary-900/30 ring-1 ring-primary-300 dark:ring-primary-700"
+                          : "border-slate-200 dark:border-dark-border bg-white dark:bg-dark-surface hover:border-slate-300 dark:hover:border-slate-500 hover:bg-slate-50 dark:hover:bg-dark-surface-alt"
                       }`}
                     >
                       {/* Visual grid preview */}
@@ -142,10 +142,14 @@ export default function NupPages() {
                           <div key={i} className="bg-slate-300 dark:bg-slate-500 rounded-sm" />
                         ))}
                       </div>
-                      <p className="text-xs font-medium text-slate-700 dark:text-dark-text">
+                      <p
+                        className={`text-xs font-semibold ${layout === l.value ? "text-primary-700 dark:text-primary-300" : "text-slate-700 dark:text-dark-text"}`}
+                      >
                         {l.label}
                       </p>
-                      <p className="text-xs text-slate-400 dark:text-dark-text-muted">{l.desc}</p>
+                      <p className="text-xs text-slate-400 dark:text-dark-text-muted leading-snug">
+                        {l.desc}
+                      </p>
                     </button>
                   ))}
                 </div>

--- a/src/tools/OcrPdf.tsx
+++ b/src/tools/OcrPdf.tsx
@@ -188,10 +188,10 @@ export default function OcrPdf() {
           {pages.length === 0 ? (
             <div className="space-y-4">
               {/* Language pill selector */}
-              <div>
-                <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-3">
+              <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4">
+                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-3">
                   OCR Language
-                </label>
+                </p>
                 <div className="flex flex-wrap gap-2">
                   {LANGUAGES.map((lang) => (
                     <button
@@ -201,7 +201,7 @@ export default function OcrPdf() {
                       className={`px-3.5 py-1.5 rounded-full text-sm font-medium transition-all ${
                         language === lang.code
                           ? "bg-primary-600 text-white shadow-sm"
-                          : "bg-slate-100 dark:bg-dark-surface text-slate-600 dark:text-dark-text-muted border border-slate-200 dark:border-dark-border hover:bg-slate-200 dark:hover:bg-dark-border"
+                          : "bg-slate-100 dark:bg-dark-bg text-slate-600 dark:text-dark-text-muted border border-slate-200 dark:border-dark-border hover:bg-slate-200 dark:hover:bg-dark-border"
                       } disabled:opacity-50 disabled:cursor-not-allowed`}
                     >
                       {lang.label}

--- a/src/tools/PdfPassword.tsx
+++ b/src/tools/PdfPassword.tsx
@@ -11,6 +11,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { Eye, EyeOff, ChevronRight, AlertTriangle } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { isPdfEncrypted, protectPdf, unlockPdf } from "../utils/pdf-security.ts";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
@@ -66,52 +67,6 @@ const PERMISSION_ROWS: { key: keyof Permissions; label: string; description: str
   },
 ];
 
-// Eye icon (open)
-function IconEyeOpen() {
-  return (
-    <svg
-      className="w-4 h-4"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-      />
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-      />
-    </svg>
-  );
-}
-
-// Eye icon (closed / slashed)
-function IconEyeOff() {
-  return (
-    <svg
-      className="w-4 h-4"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={2}
-        d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"
-      />
-    </svg>
-  );
-}
-
 interface PasswordFieldProps {
   id: string;
   label: string;
@@ -162,7 +117,7 @@ function PasswordField({
           className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-dark-text transition-colors"
           aria-label={show ? "Hide password" : "Show password"}
         >
-          {show ? <IconEyeOff /> : <IconEyeOpen />}
+          {show ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
         </button>
       </div>
     </div>
@@ -359,15 +314,9 @@ export default function PdfPassword() {
             onClick={() => setShowPerms((v) => !v)}
             className="flex items-center gap-2 text-sm font-medium text-slate-600 dark:text-dark-text-muted hover:text-slate-800 dark:hover:text-dark-text transition-colors"
           >
-            <svg
+            <ChevronRight
               className={`w-4 h-4 transition-transform ${showPerms ? "rotate-90" : ""}`}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
+            />
             Restrict permissions
           </button>
 
@@ -403,20 +352,7 @@ export default function PdfPassword() {
               </div>
 
               <div className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
-                <svg
-                  className="mt-0.5 h-4 w-4 shrink-0 text-amber-500 dark:text-amber-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
-                  />
-                </svg>
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500 dark:text-amber-400" />
                 <p className="text-xs text-amber-700 dark:text-amber-300">
                   Permission restrictions are enforced by Adobe Acrobat/Reader. Other viewers such
                   as macOS Preview and Chrome may ignore them and allow all operations regardless.

--- a/src/tools/PdfToImage.tsx
+++ b/src/tools/PdfToImage.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useCallback } from "react";
+import { Image, ScanLine } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { PageThumbnail } from "../components/PageThumbnail.tsx";
 import { renderPagesToBlobs } from "../utils/pdf-renderer.ts";
@@ -165,7 +166,8 @@ export default function PdfToImage() {
               <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                    <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                      <Image className="w-3.5 h-3.5" />
                       Format
                     </p>
                     <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
@@ -186,7 +188,8 @@ export default function PdfToImage() {
                   </div>
 
                   <div>
-                    <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                    <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                      <ScanLine className="w-3.5 h-3.5" />
                       Resolution
                     </p>
                     <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">

--- a/src/tools/PdfToImage.tsx
+++ b/src/tools/PdfToImage.tsx
@@ -162,21 +162,21 @@ export default function PdfToImage() {
               </div>
 
               {/* Export options */}
-              <div className="bg-slate-50 dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border p-4 space-y-4">
+              <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4 space-y-4">
                 <div className="grid grid-cols-2 gap-4">
                   <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5">
+                    <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                       Format
-                    </label>
-                    <div className="flex gap-2">
+                    </p>
+                    <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
                       {(["image/png", "image/jpeg"] as const).map((f) => (
                         <button
                           key={f}
                           onClick={() => setFormat(f)}
-                          className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                          className={`flex-1 rounded-lg py-1.5 px-3 text-sm transition-all duration-150 ${
                             format === f
-                              ? "bg-primary-600 text-white border-primary-600"
-                              : "border-slate-300 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:border-primary-400"
+                              ? "font-semibold text-white bg-primary-600 shadow-sm"
+                              : "font-medium text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text hover:bg-white/60 dark:hover:bg-dark-surface-alt"
                           }`}
                         >
                           {f === "image/png" ? "PNG" : "JPEG"}
@@ -186,35 +186,35 @@ export default function PdfToImage() {
                   </div>
 
                   <div>
-                    <label className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5">
+                    <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                       Resolution
-                    </label>
-                    <div className="flex gap-2">
+                    </p>
+                    <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
                       {([72, 150, 300] as const).map((d) => (
                         <button
                           key={d}
                           onClick={() => setDpi(d)}
-                          className={`flex-1 py-2 rounded-lg text-sm font-medium border transition-colors ${
+                          className={`flex-1 rounded-lg py-1.5 px-3 text-sm transition-all duration-150 ${
                             dpi === d
-                              ? "bg-primary-600 text-white border-primary-600"
-                              : "border-slate-300 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:border-primary-400"
+                              ? "font-semibold text-white bg-primary-600 shadow-sm"
+                              : "font-medium text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text hover:bg-white/60 dark:hover:bg-dark-surface-alt"
                           }`}
                         >
                           {d}
                         </button>
                       ))}
                     </div>
-                    <p className="text-xs text-slate-400 dark:text-dark-text-muted mt-1">DPI</p>
+                    <p className="text-xs text-slate-400 dark:text-dark-text-muted mt-1.5">DPI</p>
                   </div>
                 </div>
 
                 {format === "image/jpeg" && (
-                  <div>
-                    <div className="flex justify-between mb-1.5">
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
                       <label className="text-sm font-medium text-slate-700 dark:text-dark-text">
                         JPEG Quality
                       </label>
-                      <span className="text-sm text-slate-500 dark:text-dark-text-muted">
+                      <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
                         {quality}%
                       </span>
                     </div>
@@ -225,9 +225,9 @@ export default function PdfToImage() {
                       step={1}
                       value={quality}
                       onChange={(e) => setQuality(Number(e.target.value))}
-                      className="w-full accent-primary-600"
+                      className="w-full accent-primary-600 cursor-pointer"
                     />
-                    <div className="flex justify-between text-xs text-slate-400 dark:text-dark-text-muted mt-0.5">
+                    <div className="flex justify-between text-xs text-slate-400 dark:text-dark-text-muted">
                       <span>Smaller</span>
                       <span>Higher quality</span>
                     </div>

--- a/src/tools/RemoveBlankPages.tsx
+++ b/src/tools/RemoveBlankPages.tsx
@@ -13,6 +13,7 @@ import { PageThumbnail } from "../components/PageThumbnail.tsx";
 import { deletePages } from "../utils/pdf-operations.ts";
 import { renderThumbnailsAndScores } from "../utils/pdf-renderer.ts";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
+import { Trash2 } from "lucide-react";
 
 export default function RemoveBlankPages() {
   const [file, setFile] = useState<File | null>(null);
@@ -177,19 +178,7 @@ export default function RemoveBlankPages() {
                     overlay={
                       selectedPages.has(i) ? (
                         <div className="bg-amber-400/70 inset-0 absolute flex items-center justify-center">
-                          <svg
-                            className="w-8 h-8 text-white"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                            />
-                          </svg>
+                          <Trash2 className="w-8 h-8 text-white" />
                         </div>
                       ) : null
                     }

--- a/src/tools/RemoveBlankPages.tsx
+++ b/src/tools/RemoveBlankPages.tsx
@@ -136,12 +136,12 @@ export default function RemoveBlankPages() {
           ) : (
             <>
               {/* Sensitivity slider */}
-              <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border p-4">
+              <div className="bg-white dark:bg-dark-surface rounded-xl border border-slate-200 dark:border-dark-border shadow-sm p-4">
                 <div className="flex items-center justify-between mb-2">
                   <p className="text-sm font-medium text-slate-700 dark:text-dark-text">
                     Detection sensitivity
                   </p>
-                  <span className="text-xs text-slate-500 dark:text-dark-text-muted">
+                  <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
                     {Math.round(threshold * 100)}% white
                   </span>
                 </div>
@@ -152,7 +152,7 @@ export default function RemoveBlankPages() {
                   step={0.01}
                   value={threshold}
                   onChange={(e) => setThreshold(Number(e.target.value))}
-                  className="w-full accent-primary-600"
+                  className="w-full accent-primary-600 cursor-pointer"
                 />
                 <div className="flex justify-between text-xs text-slate-400 dark:text-dark-text-muted mt-1">
                   <span>Lenient (catch lightly filled pages)</span>

--- a/src/tools/ReorderPages.tsx
+++ b/src/tools/ReorderPages.tsx
@@ -13,6 +13,7 @@ import { FileDropZone } from "../components/FileDropZone.tsx";
 import { reorderPages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
 import { downloadPdf } from "../utils/file-helpers.ts";
+import { useSortableDrag } from "../hooks/useSortableDrag.ts";
 
 export default function ReorderPages() {
   const [file, setFile] = useState<File | null>(null);
@@ -23,9 +24,19 @@ export default function ReorderPages() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Drag state
-  const [dragIndex, setDragIndex] = useState<number | null>(null);
-  const [dragOverSlot, setDragOverSlot] = useState<number | null>(null);
+  const handleMove = useCallback((fromIndex: number, toSlot: number) => {
+    setOrder((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(fromIndex, 1);
+      const adjustedSlot = fromIndex < toSlot ? toSlot - 1 : toSlot;
+      next.splice(adjustedSlot, 0, moved);
+      return next;
+    });
+  }, []);
+
+  // Drag state (desktop + mobile touch)
+  const { dragIndex, dragOverSlot, setDragIndex, setDragOverSlot, getTouchHandlers } =
+    useSortableDrag(handleMove);
 
   const handleFile = useCallback(async (files: File[]) => {
     const pdf = files[0];
@@ -68,7 +79,7 @@ export default function ReorderPages() {
     setOrder(thumbnails.map((_, i) => i));
     setDragIndex(null);
     setDragOverSlot(null);
-  }, [thumbnails]);
+  }, [thumbnails, setDragIndex, setDragOverSlot]);
 
   const isReordered = order.some((pageIdx, i) => pageIdx !== i);
   const isDragging = dragIndex !== null;
@@ -92,6 +103,7 @@ export default function ReorderPages() {
       items.push(
         <div
           key={`drop-${slot}`}
+          data-drop-slot={slot}
           onDragOver={(e) => {
             if (isAdjacentToDrag) return;
             e.preventDefault();
@@ -154,6 +166,7 @@ export default function ReorderPages() {
               setDragIndex(null);
               setDragOverSlot(null);
             }}
+            {...getTouchHandlers(slot)}
             className={`shrink-0 pt-2 pr-2 flex flex-col items-center gap-1.5 cursor-grab active:cursor-grabbing select-none transition-all duration-200 ${
               isSource ? "scale-95 opacity-30" : "scale-100 opacity-100"
             }`}

--- a/src/tools/ReorderPages.tsx
+++ b/src/tools/ReorderPages.tsx
@@ -14,6 +14,7 @@ import { reorderPages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
 import { downloadPdf } from "../utils/file-helpers.ts";
 import { useSortableDrag } from "../hooks/useSortableDrag.ts";
+import { Undo2 } from "lucide-react";
 
 export default function ReorderPages() {
   const [file, setFile] = useState<File | null>(null);
@@ -252,17 +253,7 @@ export default function ReorderPages() {
                       onClick={handleReset}
                       className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted dark:hover:text-dark-text transition-colors"
                     >
-                      <svg
-                        className="w-4 h-4"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="M3 10h10a5 5 0 0 1 5 5v2M3 10l4-4m-4 4l4 4" />
-                      </svg>
+                      <Undo2 className="w-4 h-4" />
                       Reset order
                     </button>
                   )}

--- a/src/tools/ReversePages.tsx
+++ b/src/tools/ReversePages.tsx
@@ -10,6 +10,7 @@ import { FileDropZone } from "../components/FileDropZone.tsx";
 import { reversePages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
 import { downloadPdf, formatFileSize } from "../utils/file-helpers.ts";
+import { ArrowRight } from "lucide-react";
 
 export default function ReversePages() {
   const [file, setFile] = useState<File | null>(null);
@@ -126,19 +127,7 @@ export default function ReversePages() {
                   )}
                 </div>
 
-                <svg
-                  className="w-6 h-6 text-slate-400 dark:text-dark-text-muted shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17 8l4 4m0 0l-4 4m4-4H3"
-                  />
-                </svg>
+                <ArrowRight className="w-6 h-6 text-slate-400 dark:text-dark-text-muted shrink-0" />
 
                 <div className="flex items-center gap-2 flex-1 min-w-0">
                   {pageCount > 1 && (

--- a/src/tools/RotatePages.tsx
+++ b/src/tools/RotatePages.tsx
@@ -10,6 +10,7 @@
 import { useState, useCallback } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { PageThumbnail } from "../components/PageThumbnail.tsx";
+import { RotateCcw, RotateCw, FlipVertical2 } from "lucide-react";
 import { rotatePages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
 import { downloadPdf } from "../utils/file-helpers.ts";
@@ -134,57 +135,21 @@ export default function RotatePages() {
                       className="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-dark-surface-alt text-slate-500 dark:text-dark-text-muted transition-colors"
                       title="Rotate 90° left"
                     >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M3 10h10a5 5 0 015 5v2M3 10l4-4m-4 4l4 4"
-                        />
-                      </svg>
+                      <RotateCcw className="w-4 h-4" />
                     </button>
                     <button
                       onClick={() => rotatePage(i, 90)}
                       className="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-dark-surface-alt text-slate-500 dark:text-dark-text-muted transition-colors"
                       title="Rotate 90° right"
                     >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M21 10H11a5 5 0 00-5 5v2m15-7l-4-4m4 4l-4 4"
-                        />
-                      </svg>
+                      <RotateCw className="w-4 h-4" />
                     </button>
                     <button
                       onClick={() => rotatePage(i, 180)}
                       className="p-1.5 rounded hover:bg-slate-100 dark:hover:bg-dark-surface-alt text-slate-500 dark:text-dark-text-muted transition-colors"
                       title="Rotate 180°"
                     >
-                      <svg
-                        className="w-4 h-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                          strokeWidth={2}
-                          d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"
-                        />
-                      </svg>
+                      <FlipVertical2 className="w-4 h-4" />
                     </button>
                   </div>
                 </div>

--- a/src/tools/StampPdf.tsx
+++ b/src/tools/StampPdf.tsx
@@ -8,6 +8,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Stamp, CircleDot, Droplets } from "lucide-react";
 import { ColorPicker, hexToRgb, rgbToHex } from "../components/ColorPicker.tsx";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { PageThumbnail } from "../components/PageThumbnail.tsx";
@@ -348,7 +349,7 @@ export default function StampPdf() {
             <div className="space-y-5">
               {/* Stamp style toggle */}
               <div>
-                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                <p className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
                   Mode
                 </p>
                 <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
@@ -363,7 +364,21 @@ export default function StampPdf() {
                           : "font-medium text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text hover:bg-white/60 dark:hover:bg-dark-surface-alt"
                       }`}
                     >
-                      {style === "text" ? "⌶ Stamp" : style === "seal" ? "◎ Seal" : "💧 Watermark"}
+                      <span className="flex items-center justify-center gap-1.5">
+                        {style === "text" ? (
+                          <>
+                            <Stamp className="w-3.5 h-3.5" /> Stamp
+                          </>
+                        ) : style === "seal" ? (
+                          <>
+                            <CircleDot className="w-3.5 h-3.5" /> Seal
+                          </>
+                        ) : (
+                          <>
+                            <Droplets className="w-3.5 h-3.5" /> Watermark
+                          </>
+                        )}
+                      </span>
                     </button>
                   ))}
                 </div>
@@ -601,20 +616,7 @@ export default function StampPdf() {
                                   selectedPages.has(i) ? (
                                     <div className="bg-primary-600/20 inset-0 absolute flex items-center justify-center">
                                       <div className="w-5 h-5 rounded-full bg-primary-600 flex items-center justify-center shadow">
-                                        <svg
-                                          className="w-3 h-3 text-white"
-                                          fill="none"
-                                          stroke="currentColor"
-                                          viewBox="0 0 24 24"
-                                          aria-label="Selected"
-                                        >
-                                          <path
-                                            strokeLinecap="round"
-                                            strokeLinejoin="round"
-                                            strokeWidth={3}
-                                            d="M5 13l4 4L19 7"
-                                          />
-                                        </svg>
+                                        <Check className="w-3 h-3 text-white" strokeWidth={3} />
                                       </div>
                                     </div>
                                   ) : null

--- a/src/tools/StampPdf.tsx
+++ b/src/tools/StampPdf.tsx
@@ -348,17 +348,19 @@ export default function StampPdf() {
             <div className="space-y-5">
               {/* Stamp style toggle */}
               <div>
-                <p className="text-sm font-medium text-slate-700 dark:text-dark-text mb-2">Mode</p>
-                <div className="flex gap-2">
+                <p className="text-xs font-semibold uppercase tracking-widest text-slate-400 dark:text-dark-text-muted mb-2">
+                  Mode
+                </p>
+                <div className="inline-flex w-full items-center gap-0.5 rounded-xl bg-slate-100 dark:bg-dark-bg p-1 border border-slate-200 dark:border-dark-border">
                   {(["text", "seal", "watermark"] as const).map((style) => (
                     <button
                       key={style}
                       type="button"
                       onClick={() => setStampStyle(style)}
-                      className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium border-2 transition-all ${
+                      className={`flex-1 rounded-lg py-1.5 px-3 text-sm transition-all duration-150 ${
                         stampStyle === style
-                          ? "border-primary-500 bg-primary-50 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300 ring-2 ring-primary-200 dark:ring-primary-800"
-                          : "border-slate-200 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:border-slate-300"
+                          ? "font-semibold text-white bg-primary-600 shadow-sm"
+                          : "font-medium text-slate-500 dark:text-dark-text-muted hover:text-slate-700 dark:hover:text-dark-text hover:bg-white/60 dark:hover:bg-dark-surface-alt"
                       }`}
                     >
                       {style === "text" ? "⌶ Stamp" : style === "seal" ? "◎ Seal" : "💧 Watermark"}
@@ -386,13 +388,18 @@ export default function StampPdf() {
                     />
                   </div>
 
-                  <div>
-                    <label
-                      htmlFor="watermark-font-size"
-                      className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5"
-                    >
-                      Font Size: {fontSize}px
-                    </label>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <label
+                        htmlFor="watermark-font-size"
+                        className="text-sm font-medium text-slate-700 dark:text-dark-text"
+                      >
+                        Font Size
+                      </label>
+                      <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
+                        {fontSize}px
+                      </span>
+                    </div>
                     <input
                       id="watermark-font-size"
                       type="range"
@@ -400,17 +407,22 @@ export default function StampPdf() {
                       max={120}
                       value={fontSize}
                       onChange={(e) => setFontSize(Number(e.target.value))}
-                      className="w-full accent-primary-600"
+                      className="w-full accent-primary-600 cursor-pointer"
                     />
                   </div>
 
-                  <div>
-                    <label
-                      htmlFor="watermark-opacity"
-                      className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5"
-                    >
-                      Opacity: {Math.round(opacity * 100)}%
-                    </label>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <label
+                        htmlFor="watermark-opacity"
+                        className="text-sm font-medium text-slate-700 dark:text-dark-text"
+                      >
+                        Opacity
+                      </label>
+                      <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
+                        {Math.round(opacity * 100)}%
+                      </span>
+                    </div>
                     <input
                       id="watermark-opacity"
                       type="range"
@@ -418,17 +430,22 @@ export default function StampPdf() {
                       max={100}
                       value={Math.round(opacity * 100)}
                       onChange={(e) => setOpacity(Number(e.target.value) / 100)}
-                      className="w-full accent-primary-600"
+                      className="w-full accent-primary-600 cursor-pointer"
                     />
                   </div>
 
-                  <div>
-                    <label
-                      htmlFor="watermark-rotation"
-                      className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5"
-                    >
-                      Rotation: {rotation}°
-                    </label>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <label
+                        htmlFor="watermark-rotation"
+                        className="text-sm font-medium text-slate-700 dark:text-dark-text"
+                      >
+                        Rotation
+                      </label>
+                      <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
+                        {rotation}°
+                      </span>
+                    </div>
                     <input
                       id="watermark-rotation"
                       type="range"
@@ -436,7 +453,7 @@ export default function StampPdf() {
                       max={90}
                       value={rotation}
                       onChange={(e) => setRotation(Number(e.target.value))}
-                      className="w-full accent-primary-600"
+                      className="w-full accent-primary-600 cursor-pointer"
                     />
                   </div>
 
@@ -469,13 +486,18 @@ export default function StampPdf() {
                     </div>
                   </div>
 
-                  <div>
-                    <label
-                      htmlFor="stamp-font-size"
-                      className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5"
-                    >
-                      Size: {fontSize}pt
-                    </label>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <label
+                        htmlFor="stamp-font-size"
+                        className="text-sm font-medium text-slate-700 dark:text-dark-text"
+                      >
+                        Size
+                      </label>
+                      <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
+                        {fontSize}pt
+                      </span>
+                    </div>
                     <input
                       id="stamp-font-size"
                       type="range"
@@ -483,17 +505,22 @@ export default function StampPdf() {
                       max={120}
                       value={fontSize}
                       onChange={(e) => setFontSize(Number(e.target.value))}
-                      className="w-full accent-primary-600"
+                      className="w-full accent-primary-600 cursor-pointer"
                     />
                   </div>
 
-                  <div>
-                    <label
-                      htmlFor="stamp-opacity"
-                      className="block text-sm font-medium text-slate-700 dark:text-dark-text mb-1.5"
-                    >
-                      Opacity: {Math.round(opacity * 100)}%
-                    </label>
+                  <div className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <label
+                        htmlFor="stamp-opacity"
+                        className="text-sm font-medium text-slate-700 dark:text-dark-text"
+                      >
+                        Opacity
+                      </label>
+                      <span className="inline-flex items-center rounded-full bg-primary-100 dark:bg-primary-900/40 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:text-primary-300 tabular-nums">
+                        {Math.round(opacity * 100)}%
+                      </span>
+                    </div>
                     <input
                       id="stamp-opacity"
                       type="range"
@@ -501,7 +528,7 @@ export default function StampPdf() {
                       max={100}
                       value={Math.round(opacity * 100)}
                       onChange={(e) => setOpacity(Number(e.target.value) / 100)}
-                      className="w-full accent-primary-600"
+                      className="w-full accent-primary-600 cursor-pointer"
                     />
                   </div>
                 </>


### PR DESCRIPTION
This pull request introduces the `lucide-react` icon library and refactors the codebase to use these modern, consistent icons instead of inline SVGs. It also adds a new shared drag-and-drop hook for improved touch and desktop support when reordering pages, and updates documentation and dependencies accordingly.

**Icon library integration and icon refactor:**

* Added `lucide-react` as a dependency and updated `pnpm-lock.yaml` to include it. All major UI icons (search, upload, navigation, lock, etc.) are now imported from `lucide-react` instead of being defined as inline SVGs, resulting in a cleaner and more maintainable codebase. (`package.json`, `pnpm-lock.yaml`, `README.md`, `src/App.tsx`, `src/components/FileDropZone.tsx`, `src/components/Layout.tsx`, [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R15) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR21-R23) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1894-R1898) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4225-R4228) [[5]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R36) [[6]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L457-R458) [[7]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L492-R481) [[8]](diffhunk://#diff-b34a828101ac21cd6f2af85f5303f29b2725468e35fdb967fb807bc02aac8133R11) [[9]](diffhunk://#diff-b34a828101ac21cd6f2af85f5303f29b2725468e35fdb967fb807bc02aac8133L78-L90) [[10]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4R10) [[11]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L49-R58) [[12]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L129-R72) [[13]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L158-R92)

* Updated the main logo in the layout to use an image (`/icons/logo.svg`) instead of an inline SVG, simplifying the logo rendering. (`src/components/Layout.tsx`, [src/components/Layout.tsxL49-R58](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L49-R58))

**Drag-and-drop improvements:**

* Added a new `useSortableDrag` hook to `src/hooks/useSortableDrag.ts` that provides unified drag-and-drop support for both mouse and touch events, improving the UX for page reordering on desktop and mobile. (`src/hooks/useSortableDrag.ts`, [src/hooks/useSortableDrag.tsR1-R117](diffhunk://#diff-36133f2bbc4482f69c4699d12454079ff1fdc1f7e5b548eff087e44485b1f9a3R1-R117))

* Refactored the `AddBlankPage` tool to use the new `useSortableDrag` hook, simplifying its drag state management and ensuring consistent drag-and-drop behavior across devices. (`src/tools/AddBlankPage.tsx`, [[1]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680R12-R15) [[2]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680L32-R46) [[3]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680L71-R83) [[4]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680R121) [[5]](diffhunk://#diff-c57024c8e55672275f0947199bb53d8d62c41ad89fa2346e66d6be3ba0071680R184)

**Documentation and metadata:**

* Updated the README to reflect the new icon library and changed the live demo link to the new domain (`bytepdf.app`). (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R100)