### PR TITLE
Refactor ExtractPages and RedactPdf components for UI consistency

### DIFF
--- a/src/tools/ExtractPages.tsx
+++ b/src/tools/ExtractPages.tsx
@@ -7,13 +7,13 @@
  * written to a new PDF and downloaded.
  */
 
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
+import { Check, CheckSquare, X } from "lucide-react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
 import { PageThumbnail } from "../components/PageThumbnail.tsx";
+import { downloadPdf } from "../utils/file-helpers.ts";
 import { extractPages } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
-import { downloadPdf } from "../utils/file-helpers.ts";
-import { Check } from "lucide-react";
 
 /** Parse a range string like "1-3, 5, 7-9" into sorted, unique 0-based page indices. */
 function parseRangeInput(input: string, pageCount: number): number[] {
@@ -35,6 +35,7 @@ function parseRangeInput(input: string, pageCount: number): number[] {
 export default function ExtractPages() {
   const [file, setFile] = useState<File | null>(null);
   const [thumbnails, setThumbnails] = useState<string[]>([]);
+  const [pageIds, setPageIds] = useState<string[]>([]);
   const [selectedPages, setSelectedPages] = useState<Set<number>>(new Set());
   const [rangeInput, setRangeInput] = useState("");
   const [processing, setProcessing] = useState(false);
@@ -52,6 +53,7 @@ export default function ExtractPages() {
     try {
       const thumbs = await renderAllThumbnails(pdf);
       setThumbnails(thumbs);
+      setPageIds(thumbs.map((_, idx) => `${pdf.name}-${idx}`));
     } catch (e) {
       setError(
         e instanceof Error
@@ -122,8 +124,8 @@ export default function ExtractPages() {
         />
       ) : (
         <>
-          <div className="flex items-center justify-between flex-wrap gap-2">
-            <p className="text-sm text-slate-600 dark:text-dark-text-muted">
+          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+            <p className="text-sm text-slate-600 dark:text-dark-text-muted break-all sm:break-normal">
               <span className="font-medium">{file.name}</span> — {thumbnails.length} pages
               {selectedPages.size > 0 && !rangeInput.trim() && (
                 <span className="text-primary-600 dark:text-primary-400 ml-2">
@@ -133,18 +135,23 @@ export default function ExtractPages() {
             </p>
             <div className="flex items-center gap-3">
               <button
+                type="button"
                 onClick={selectAll}
-                className="text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400"
+                className="inline-flex items-center gap-1.5 text-sm text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 transition-colors"
               >
+                <CheckSquare className="w-4 h-4" />
                 Select all
               </button>
               <button
+                type="button"
                 onClick={clearAll}
-                className="text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted"
+                className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted dark:hover:text-dark-text transition-colors"
               >
+                <X className="w-4 h-4" />
                 Clear
               </button>
               <button
+                type="button"
                 onClick={() => {
                   setFile(null);
                   setThumbnails([]);
@@ -186,7 +193,7 @@ export default function ExtractPages() {
             <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-3">
               {thumbnails.map((thumb, i) => (
                 <PageThumbnail
-                  key={i}
+                  key={pageIds[i]}
                   src={thumb}
                   pageNumber={i + 1}
                   selected={selectedPages.has(i)}

--- a/src/tools/RedactPdf.tsx
+++ b/src/tools/RedactPdf.tsx
@@ -8,11 +8,12 @@
  * permanent filled black boxes via pdf-lib.
  */
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { FileDropZone } from "../components/FileDropZone.tsx";
+import { downloadPdf } from "../utils/file-helpers.ts";
 import { redactPdf } from "../utils/pdf-operations.ts";
 import { renderAllThumbnails } from "../utils/pdf-renderer.ts";
-import { downloadPdf } from "../utils/file-helpers.ts";
+import { Trash2, Undo2 } from "lucide-react";
 
 interface RedactionRect {
   xPct: number;
@@ -235,8 +236,8 @@ export default function RedactPdf() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between flex-wrap gap-2">
-        <p className="text-sm text-slate-600 dark:text-dark-text-muted">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
+        <p className="text-sm text-slate-600 dark:text-dark-text-muted break-all sm:break-normal">
           <span className="font-medium">{file.name}</span> — {thumbnails.length} pages
           {totalRedactions > 0 && (
             <span className="text-red-600 dark:text-red-400 ml-2">
@@ -283,16 +284,18 @@ export default function RedactPdf() {
                 type="button"
                 onClick={removeLastRect}
                 disabled={(redactions.get(editingPage) ?? []).length === 0}
-                className="text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted disabled:opacity-40"
+                className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-700 dark:text-dark-text-muted dark:hover:text-dark-text disabled:opacity-40 transition-colors"
               >
+                <Undo2 className="w-4 h-4" />
                 Undo last
               </button>
               <button
                 type="button"
                 onClick={clearPageRects}
                 disabled={(redactions.get(editingPage) ?? []).length === 0}
-                className="text-sm text-red-500 hover:text-red-700 disabled:opacity-40"
+                className="inline-flex items-center gap-1.5 text-sm text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 disabled:opacity-40 transition-colors"
               >
+                <Trash2 className="w-4 h-4" />
                 Clear page
               </button>
             </div>


### PR DESCRIPTION
This pull request focuses on improving the user interface and accessibility of the PDF tools by enhancing button visuals with icons, refining layout responsiveness, and improving key management for thumbnail components. The changes also include minor import reordering for consistency.

**UI Enhancements:**

* Added Lucide icons (`CheckSquare`, `X`, `Undo2`, `Trash2`) to action buttons such as "Select all", "Clear", "Undo last", and "Clear page" for clearer visual cues and improved accessibility in both `ExtractPages` and `RedactPdf`. Button styles were updated to better support dark mode, transitions, and to align icons with text. [[1]](diffhunk://#diff-c6961de4f3c6b2116c7aab94e5f0f760708f0c9937bfa6f46aaa82f1384bd6a3L10-L16) [[2]](diffhunk://#diff-c6961de4f3c6b2116c7aab94e5f0f760708f0c9937bfa6f46aaa82f1384bd6a3R138-R154) [[3]](diffhunk://#diff-4f46134f16a48d369cb2a2d813254b1ffb500d76fb7c93140cc6a3d01f414582L11-R16) [[4]](diffhunk://#diff-4f46134f16a48d369cb2a2d813254b1ffb500d76fb7c93140cc6a3d01f414582L286-R298)

* Updated layout of file information and action buttons to use a more responsive and accessible flexbox structure, improving appearance on small screens and preventing text overflow. [[1]](diffhunk://#diff-c6961de4f3c6b2116c7aab94e5f0f760708f0c9937bfa6f46aaa82f1384bd6a3L125-R128) [[2]](diffhunk://#diff-4f46134f16a48d369cb2a2d813254b1ffb500d76fb7c93140cc6a3d01f414582L238-R240)

**Code Quality and Consistency:**

* Reordered imports for consistency and clarity in both `ExtractPages.tsx` and `RedactPdf.tsx`. [[1]](diffhunk://#diff-c6961de4f3c6b2116c7aab94e5f0f760708f0c9937bfa6f46aaa82f1384bd6a3L10-L16) [[2]](diffhunk://#diff-4f46134f16a48d369cb2a2d813254b1ffb500d76fb7c93140cc6a3d01f414582L11-R16)

**Component Improvements:**

* Improved the uniqueness and stability of React keys for `PageThumbnail` components by generating unique `pageIds` based on file name and index, reducing the risk of rendering bugs. [[1]](diffhunk://#diff-c6961de4f3c6b2116c7aab94e5f0f760708f0c9937bfa6f46aaa82f1384bd6a3R38) [[2]](diffhunk://#diff-c6961de4f3c6b2116c7aab94e5f0f760708f0c9937bfa6f46aaa82f1384bd6a3R56) [[3]](diffhunk://#diff-c6961de4f3c6b2116c7aab94e5f0f760708f0c9937bfa6f46aaa82f1384bd6a3L189-R196)