### PR TITLE
fix: correct badge label in README and update dependency audit command

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,4 +29,4 @@ jobs:
           run-install: true
 
       - name: Run dependency audit
-        run: vp pm audit --audit-level=high
+        run: vp pm audit -- --audit-level=high

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <p>
     <img src="https://img.shields.io/github/actions/workflow/status/sumitsahoo/bytepdf/deploy.yml?label=build" alt="Build status" />
     <img src="https://img.shields.io/github/deployments/sumitsahoo/bytepdf/github-pages?label=deploy" alt="Deployment" />
-    <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License" /></a>
+    <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-yellow.svg" alt="MIT License" /></a>
   </p>
   <p>
     <img src="https://img.shields.io/github/actions/workflow/status/sumitsahoo/bytepdf/security.yml?label=security%20audit" alt="Security audit" />


### PR DESCRIPTION
This pull request includes minor improvements to the documentation and CI workflow configuration. The most notable changes are a fix to the dependency audit command in the security workflow and a small update to the license badge in the `README.md`.

- **CI/CD Workflow Improvements:**
  - Fixed the `vp pm audit` command in `.github/workflows/security.yml` by adding `--` before `--audit-level=high` to ensure proper argument parsing.

- **Documentation Updates:**
  - Updated the MIT license badge in `README.md` to use a lowercase "license" label for consistency.