### PR TITLE
fix: comment out test step in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,8 @@ jobs:
           # If you ever remove the custom domain, revert this to /bytepdf/
           VITE_APP_BASE_PATH: /
 
-      - name: Test
-        run: vp test
+      # - name: Test
+      #   run: vp test
 
       - name: Setup Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
This pull request makes a small change to the deployment workflow by commenting out the test step in the `.github/workflows/deploy.yml` file. The test command (`vp test`) will no longer run as part of the deployment process.