### PR TITLE
fix: update scorecard-action version in workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard-results.sarif
           results_format: sarif


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow by changing the commit reference for the `ossf/scorecard-action` used in the `scorecard.yml` workflow file. The version remains the same (`v2.4.3`), but the action now points to a different commit hash.

* Updated the `ossf/scorecard-action` in `.github/workflows/scorecard.yml` to use a new commit reference while keeping the version at `v2.4.3`.