### PR TITLE
feat: add CODEOWNERS file to define default code owner for all files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owner for all files
+* @sumitsahoo


### PR DESCRIPTION
This pull request introduces a default code owner for the repository by updating the `.github/CODEOWNERS` file.

Repository ownership:

* Set `@sumitsahoo` as the default code owner for all files in the repository (`.github/CODEOWNERS`).