### PR TITLE
Remove unnecessary dark background class from SignaturePad component

### DIFF
--- a/src/components/SignaturePad.tsx
+++ b/src/components/SignaturePad.tsx
@@ -190,7 +190,7 @@ export function SignaturePad({ onSignature, color, width = 500, height = 200 }: 
   return (
     <div className="space-y-1.5">
       <div
-        className={`relative border rounded-xl overflow-hidden bg-white dark:bg-dark-surface motion-safe:transition-[border-color,box-shadow] duration-200 ${
+        className={`relative border rounded-xl overflow-hidden bg-white motion-safe:transition-[border-color,box-shadow] duration-200 ${
           isDrawing
             ? "border-primary-400 dark:border-primary-500 shadow-[0_0_0_3px_rgba(99,102,241,0.15)]"
             : "border-slate-300 dark:border-dark-border hover:border-slate-400 dark:hover:border-slate-600"

--- a/src/tools/AddSignature.tsx
+++ b/src/tools/AddSignature.tsx
@@ -380,7 +380,7 @@ export default function AddSignature() {
                     </button>
                   ) : (
                     <div className="flex items-center gap-3">
-                      <div className="w-24 h-12 rounded-md border border-slate-200 dark:border-dark-border bg-white dark:bg-dark-surface flex items-center justify-center overflow-hidden">
+                      <div className="w-24 h-12 rounded-md border border-slate-200 dark:border-dark-border bg-white flex items-center justify-center overflow-hidden">
                         <img
                           src={signatureDataUrl || uploadedImageUrl}
                           alt="Uploaded signature"


### PR DESCRIPTION
This pull request makes minor UI adjustments by removing the `dark:bg-dark-surface` class from signature-related components. This change ensures that the background color remains consistent regardless of the dark mode setting.

UI consistency improvements:

* Removed the `dark:bg-dark-surface` class from the signature pad container in `SignaturePad.tsx` to maintain a uniform background color in both light and dark modes.
* Removed the `dark:bg-dark-surface` class from the signature preview container in `AddSignature.tsx` for consistent background color display.