### PR TITLE
Enhance AddSignature component with per-page positioning and fix drag interactions

### DIFF
--- a/src/hooks/useSortableDrag.ts
+++ b/src/hooks/useSortableDrag.ts
@@ -41,6 +41,10 @@ export function useSortableDrag(onMove: (fromIndex: number, toSlot: number) => v
         touchStartPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
         isDragActive.current = false;
       },
+      // Prevent Android Chrome long-press context menu ("Open in new tab" etc.).
+      onContextMenu(e: React.MouseEvent) {
+        e.preventDefault();
+      },
       // Prevent iOS long-press callout / page preview from hijacking drag.
       style: {
         WebkitTouchCallout: "none",

--- a/src/tools/AddSignature.tsx
+++ b/src/tools/AddSignature.tsx
@@ -24,6 +24,7 @@ import { PenLine, Upload, Move, Maximize2, Check, CheckSquare, X } from "lucide-
 type SignatureMode = "draw" | "upload";
 
 const MAX_UPLOAD_SIZE = 5 * 1024 * 1024; // 5 MB
+const DEFAULT_POSITION = { xPercent: 50, yPercent: 15 };
 
 /**
  * Apply a colour tint to an image data-URL.
@@ -86,7 +87,10 @@ export default function AddSignature() {
   const [processing, setProcessing] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [position, setPosition] = useState({ xPercent: 50, yPercent: 15 });
+  const [position, setPosition] = useState(DEFAULT_POSITION);
+  const [pagePositions, setPagePositions] = useState<
+    Record<number, { xPercent: number; yPercent: number }>
+  >({});
   const [sigSize, setSigSize] = useState({ width: 200, height: 80 });
   const [pageDims, setPageDims] = useState<{ width: number; height: number }[]>([]);
   const [isDragging, setIsDragging] = useState(false);
@@ -120,6 +124,22 @@ export default function AddSignature() {
     };
   }, [mode, uploadedImageUrl, tintEnabled, color]);
 
+  // Derive current position: per-page when not applying to all, shared otherwise
+  const currentPosition = applyToAllPages
+    ? position
+    : (pagePositions[selectedPage] ?? DEFAULT_POSITION);
+
+  const setCurrentPosition = useCallback(
+    (pos: { xPercent: number; yPercent: number }) => {
+      if (applyToAllPages) {
+        setPosition(pos);
+      } else {
+        setPagePositions((prev) => ({ ...prev, [selectedPage]: pos }));
+      }
+    },
+    [applyToAllPages, selectedPage],
+  );
+
   /* ---- drag-and-drop positioning ---- */
   const handleDragStart = useCallback(
     (e: React.MouseEvent | React.TouchEvent) => {
@@ -131,12 +151,12 @@ export default function AddSignature() {
         active: true,
         startX: clientX,
         startY: clientY,
-        startXPct: position.xPercent,
-        startYPct: position.yPercent,
+        startXPct: currentPosition.xPercent,
+        startYPct: currentPosition.yPercent,
       };
       setIsDragging(true);
     },
-    [position],
+    [currentPosition],
   );
 
   useEffect(() => {
@@ -150,7 +170,7 @@ export default function AddSignature() {
       const dy = ((dragRef.current.startY - clientY) / rect.height) * 100;
       const newX = Math.max(2, Math.min(98, dragRef.current.startXPct + dx));
       const newY = Math.max(2, Math.min(98, dragRef.current.startYPct + dy));
-      setPosition({ xPercent: Math.round(newX), yPercent: Math.round(newY) });
+      setCurrentPosition({ xPercent: Math.round(newX), yPercent: Math.round(newY) });
     };
 
     const handleUp = () => {
@@ -168,7 +188,7 @@ export default function AddSignature() {
       window.removeEventListener("touchmove", handleMove);
       window.removeEventListener("touchend", handleUp);
     };
-  }, []);
+  }, [setCurrentPosition]);
 
   /* ---- page toggle for multi-select ---- */
   const togglePage = useCallback((index: number) => {
@@ -242,32 +262,56 @@ export default function AddSignature() {
       const arrayBuffer = await file.arrayBuffer();
       const { PDFDocument } = await import("@pdfme/pdf-lib");
       const pdfDoc = await PDFDocument.load(arrayBuffer);
-      const page = pdfDoc.getPage(selectedPage);
-      const { width: pageWidth, height: pageHeight } = page.getSize();
-
-      // Convert centre-based percentage position to bottom-left origin PDF coords
-      const x = (position.xPercent / 100) * pageWidth - sigSize.width / 2;
-      const y = (position.yPercent / 100) * pageHeight - sigSize.height / 2;
 
       const pageIndices = applyToAllPages
         ? Array.from({ length: pdfDoc.getPageCount() }, (_, i) => i)
         : [...selectedPages].sort((a, b) => a - b);
 
-      const result = await addSignature(file, signatureDataUrl, pageIndices, {
-        x: Math.max(0, x),
-        y: Math.max(0, y),
-        width: sigSize.width,
-        height: sigSize.height,
-      });
+      if (applyToAllPages) {
+        // Single shared position
+        const page = pdfDoc.getPage(0);
+        const { width: pageWidth, height: pageHeight } = page.getSize();
+        const x = (position.xPercent / 100) * pageWidth - sigSize.width / 2;
+        const y = (position.yPercent / 100) * pageHeight - sigSize.height / 2;
 
-      const baseName = file.name.replace(/\.pdf$/i, "");
-      downloadPdf(result, `${baseName}_signed.pdf`);
+        const result = await addSignature(file, signatureDataUrl, pageIndices, {
+          x: Math.max(0, x),
+          y: Math.max(0, y),
+          width: sigSize.width,
+          height: sigSize.height,
+        });
+        const baseName = file.name.replace(/\.pdf$/i, "");
+        downloadPdf(result, `${baseName}_signed.pdf`);
+      } else {
+        // Per-page positions
+        const positionMap = new Map<
+          number,
+          { x: number; y: number; width: number; height: number }
+        >();
+        for (const idx of pageIndices) {
+          const page = pdfDoc.getPage(idx);
+          const { width: pageWidth, height: pageHeight } = page.getSize();
+          const pos = pagePositions[idx] ?? DEFAULT_POSITION;
+          const x = (pos.xPercent / 100) * pageWidth - sigSize.width / 2;
+          const y = (pos.yPercent / 100) * pageHeight - sigSize.height / 2;
+          positionMap.set(idx, {
+            x: Math.max(0, x),
+            y: Math.max(0, y),
+            width: sigSize.width,
+            height: sigSize.height,
+          });
+        }
+
+        const result = await addSignature(file, signatureDataUrl, pageIndices, positionMap);
+        const baseName = file.name.replace(/\.pdf$/i, "");
+        downloadPdf(result, `${baseName}_signed.pdf`);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to add signature. Please try again.");
     } finally {
       setProcessing(false);
     }
-  }, [file, signatureDataUrl, selectedPage, position, sigSize, applyToAllPages, selectedPages]);
+  }, [file, signatureDataUrl, position, sigSize, applyToAllPages, selectedPages, pagePositions]);
 
   return (
     <div className="space-y-6">
@@ -293,6 +337,7 @@ export default function AddSignature() {
                 setSignatureDataUrl("");
                 setUploadedImageUrl("");
                 setSelectedPages(new Set());
+                setPagePositions({});
               }}
               className="text-sm text-primary-600 hover:text-primary-700"
             >
@@ -479,7 +524,10 @@ export default function AddSignature() {
                 <div className="flex items-start gap-2 rounded-lg bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-800 px-3 py-2.5">
                   <Move className="w-4 h-4 mt-0.5 text-primary-500 shrink-0" />
                   <p className="text-xs text-primary-700 dark:text-primary-300 leading-relaxed">
-                    Drag the signature on the preview to reposition it
+                    Drag the signature on the preview to reposition it.
+                    {thumbnails.length > 1 &&
+                      !applyToAllPages &&
+                      " Each page remembers its own position — select a page and drag to adjust."}
                   </p>
                 </div>
               )}
@@ -588,8 +636,8 @@ export default function AddSignature() {
                     <div
                       className="absolute border-2 border-dashed border-primary-400 rounded select-none touch-none"
                       style={{
-                        left: `${position.xPercent}%`,
-                        bottom: `${position.yPercent}%`,
+                        left: `${currentPosition.xPercent}%`,
+                        bottom: `${currentPosition.yPercent}%`,
                         transform: "translate(-50%, 50%)",
                         cursor: isDragging ? "grabbing" : "grab",
                         width: pageDims[selectedPage]

--- a/src/utils/pdf-operations.ts
+++ b/src/utils/pdf-operations.ts
@@ -647,7 +647,7 @@ export async function addSignature(
   file: File,
   signatureDataUrl: string,
   pageIndices: number[],
-  position: Position,
+  position: Position | Map<number, Position>,
 ): Promise<Uint8Array> {
   const arrayBuffer = await file.arrayBuffer();
   const pdf = await PDFDocument.load(arrayBuffer);
@@ -665,13 +665,18 @@ export async function addSignature(
     ? await pdf.embedJpg(signatureBytes)
     : await pdf.embedPng(signatureBytes);
 
+  const isMap = position instanceof Map;
+
   for (const idx of pageIndices) {
+    const fallback = isMap ? position.values().next().value : position;
+    const pos = isMap ? (position.get(idx) ?? fallback) : position;
+    if (!pos) continue;
     const page = pdf.getPage(idx);
     page.drawImage(signatureImage, {
-      x: position.x,
-      y: position.y,
-      width: position.width,
-      height: position.height,
+      x: pos.x,
+      y: pos.y,
+      width: pos.width,
+      height: pos.height,
     });
   }
 


### PR DESCRIPTION
This pull request enhances the signature placement workflow in the PDF signing tool by introducing per-page signature positioning. Users can now set a different signature position for each selected page, or use a single shared position for all pages. The changes also improve the drag-and-drop experience and update the PDF generation logic to support per-page positions.

**Signature placement and user experience improvements:**

* Added support for per-page signature positioning in `AddSignature.tsx`, allowing users to specify a unique signature position for each page when not applying to all pages. The UI and drag logic now use a `pagePositions` map to track positions per page, and the help text reflects this new behavior. [[1]](diffhunk://#diff-e57dbeea0df4881f4f42f6ed9c95014239456f099aaa8fbda18009482962c3bfR27) [[2]](diffhunk://#diff-e57dbeea0df4881f4f42f6ed9c95014239456f099aaa8fbda18009482962c3bfL89-R93) [[3]](diffhunk://#diff-e57dbeea0df4881f4f42f6ed9c95014239456f099aaa8fbda18009482962c3bfR127-R142) [[4]](diffhunk://#diff-e57dbeea0df4881f4f42f6ed9c95014239456f099aaa8fbda18009482962c3bfL134-R159) [[5]](diffhunk://#diff-e57dbeea0df4881f4f42f6ed9c95014239456f099aaa8fbda18009482962c3bfL153-R173) [[6]](diffhunk://#diff-e57dbeea0df4881f4f42f6ed9c95014239456f099aaa8fbda18009482962c3bfL245-R314) [[7]](diffhunk://#diff-e57dbeea0df4881f4f42f6ed9c95014239456f099aaa8fbda18009482962c3bfR340) [[8]](diffhunk://#diff-e57dbeea0df4881f4f42f6ed9c95014239456f099aaa8fbda18009482962c3bfL482-R530) [[9]](diffhunk://#diff-e57dbeea0df4881f4f42f6ed9c95014239456f099aaa8fbda18009482962c3bfL591-R640)

**PDF generation logic:**

* Updated the `addSignature` function in `pdf-operations.ts` to accept either a single position or a map of positions, and apply the correct coordinates for each page during PDF generation. [[1]](diffhunk://#diff-5f8dc62a1a449565ae0b6b662aac9f1b1fc53675d7d8aa1c3db95a0afc6a49f8L650-R650) [[2]](diffhunk://#diff-5f8dc62a1a449565ae0b6b662aac9f1b1fc53675d7d8aa1c3db95a0afc6a49f8R668-R679)

**Cross-platform drag-and-drop fixes:**

* Prevented the Android Chrome long-press context menu from appearing during drag operations by handling the `onContextMenu` event in `useSortableDrag`.