### PR TITLE
Add mobile positioning support for Aurora blobs to prevent iOS URL-bar overlap

### DIFF
--- a/src/components/AuroraBackground.tsx
+++ b/src/components/AuroraBackground.tsx
@@ -66,9 +66,24 @@ interface Props {
  * for the perf budget. Negative animation-delays decorrelate the loops
  * so the composite never visibly repeats.
  * ──────────────────────────────────────────────────────────────── */
+interface BlobAnchor {
+  top?: string;
+  right?: string;
+  bottom?: string;
+  left?: string;
+}
+
 interface BlobConfig {
   size: string;
-  pos: { top?: string; right?: string; bottom?: string; left?: string };
+  pos: BlobAnchor;
+  /**
+   * Optional mobile (<= 640px) position override. When set, REPLACES `pos`
+   * on small screens — fields not specified here resolve to `auto`, so a
+   * blob can flip from bottom-anchored to top-anchored without inheriting
+   * the desktop `bottom` value. Use this to keep an animated blob away
+   * from iOS Safari's bottom URL-bar color-sampling zone on phones.
+   */
+  posMobile?: BlobAnchor;
   colorIndex: number;
   morph: string;
   flow: string;
@@ -109,8 +124,17 @@ const BLOBS: readonly BlobConfig[] = [
     hideMobile: true,
   },
   {
+    // Re-anchored to the top on mobile: the warm orange (#ea580c) bleeds
+    // into iOS Safari's floating URL-bar color-sampling zone when this
+    // blob sits bottom-anchored on phones (the +65vh down-translate plus
+    // 1.2x scale at the 25% keyframe sweep its bounding box through the
+    // bottom 80px of the viewport). Flipping the anchor on narrow screens
+    // keeps the same animation playing in the upper half of the viewport,
+    // so the blob is still part of the composition but never reaches the
+    // URL bar sample area.
     size: "clamp(300px, 46vw, 660px)",
     pos: { bottom: "-10%", left: "-8%" },
+    posMobile: { top: "-10%", left: "-8%" },
     colorIndex: 3,
     morph: "aurora-morph-b 19s ease-in-out infinite -2s",
     flow: "aurora-flow-a 54s linear infinite -28s",
@@ -197,6 +221,13 @@ const STYLESHEET = `
      explicit z-index >= 1 paints above; siblings with no z paint above
      by tree order (since the blobs render first in this component). */
   z-index: 0;
+  /* Anchor offsets come in as inline custom properties so a media query
+     can swap the mobile set in without fighting inline-style specificity.
+     Each blob sets only the sides it uses; the rest are 'auto'. */
+  top: var(--top, auto);
+  right: var(--right, auto);
+  bottom: var(--bottom, auto);
+  left: var(--left, auto);
   width: var(--w);
   height: var(--w);
   background: var(--bg);
@@ -210,9 +241,18 @@ const STYLESHEET = `
     aurora-breathe var(--breathe-dur, 12s) ease-in-out infinite var(--breathe-delay, 0s);
 }
 /* Mobile budget: shrink the blur (the heaviest GPU op) and drop the
-   two smallest blobs that mostly add density rather than silhouette. */
+   two smallest blobs that mostly add density rather than silhouette.
+   Blobs that ship a posMobile config override their anchor offsets
+   here, so they can be re-anchored (e.g. bottom -> top) to dodge iOS
+   Safari's URL-bar color-sampling zone without disappearing entirely. */
 @media (max-width: 640px) {
   .aurora-blob { filter: blur(36px); }
+  .aurora-blob {
+    top: var(--top-m, var(--top, auto));
+    right: var(--right-m, var(--right, auto));
+    bottom: var(--bottom-m, var(--bottom, auto));
+    left: var(--left-m, var(--left, auto));
+  }
   .aurora-blob-mobile-hide { display: none; }
 }
 @media (prefers-reduced-motion: reduce) {
@@ -235,8 +275,20 @@ export function AuroraBackground({
     <div aria-hidden="true" className={`aurora-root ${className ?? ""}`} style={rootStyle}>
       <style precedence="aurora-background">{STYLESHEET}</style>
       {BLOBS.map((b) => {
+        // When posMobile is set it REPLACES pos at <=640px — unspecified
+        // sides resolve to 'auto' (not the desktop value), so a blob can
+        // flip anchors (e.g. bottom -> top) without inheriting the
+        // opposite side from the desktop config.
+        const mobile = b.posMobile ?? b.pos;
         const blobStyle: CSSProperties = {
-          ...b.pos,
+          "--top": b.pos.top ?? "auto",
+          "--right": b.pos.right ?? "auto",
+          "--bottom": b.pos.bottom ?? "auto",
+          "--left": b.pos.left ?? "auto",
+          "--top-m": mobile.top ?? "auto",
+          "--right-m": mobile.right ?? "auto",
+          "--bottom-m": mobile.bottom ?? "auto",
+          "--left-m": mobile.left ?? "auto",
           "--w": b.size,
           "--bg": colors[b.colorIndex],
           "--morph": b.morph,


### PR DESCRIPTION
This pull request enhances the flexibility and accessibility of the `AuroraBackground` component by introducing support for mobile-specific blob positioning. The main goal is to allow certain animated background blobs to avoid interfering with iOS Safari's bottom URL-bar color-sampling zone on mobile devices, while maintaining their visual presence elsewhere in the composition.

Key changes include:

**Mobile-specific blob positioning:**

* Added a new `BlobAnchor` type and an optional `posMobile` property to the `BlobConfig` interface, allowing blobs to specify alternative anchor positions for mobile screens (`<= 640px`). This enables blobs to be re-anchored (e.g., from bottom to top) on mobile without inheriting desktop anchor values.
* Updated the `BLOBS` array to use `posMobile` for blobs that need to avoid the iOS Safari URL-bar color-sampling zone, ensuring correct visual behavior on mobile devices.

**Styling and rendering adjustments:**

* Modified the CSS to use custom properties (`--top`, `--right`, `--bottom`, `--left` and their `-m` mobile counterparts) for blob positioning, allowing media queries to cleanly override anchor offsets on mobile without specificity conflicts.
* Enhanced the mobile media query to apply the `posMobile` anchor offsets when provided, so blobs can flip anchors responsively.
* Updated the rendering logic to set both desktop and mobile anchor custom properties for each blob, ensuring correct positioning across screen sizes.