### PR TITLE
Improve iOS Safari URL-bar handling for AuroraBackground and Layout

### DIFF
--- a/src/components/AuroraBackground.tsx
+++ b/src/components/AuroraBackground.tsx
@@ -66,24 +66,9 @@ interface Props {
  * for the perf budget. Negative animation-delays decorrelate the loops
  * so the composite never visibly repeats.
  * ──────────────────────────────────────────────────────────────── */
-interface BlobAnchor {
-  top?: string;
-  right?: string;
-  bottom?: string;
-  left?: string;
-}
-
 interface BlobConfig {
   size: string;
-  pos: BlobAnchor;
-  /**
-   * Optional mobile (<= 640px) position override. When set, REPLACES `pos`
-   * on small screens — fields not specified here resolve to `auto`, so a
-   * blob can flip from bottom-anchored to top-anchored without inheriting
-   * the desktop `bottom` value. Use this to keep an animated blob away
-   * from iOS Safari's bottom URL-bar color-sampling zone on phones.
-   */
-  posMobile?: BlobAnchor;
+  pos: { top?: string; right?: string; bottom?: string; left?: string };
   colorIndex: number;
   morph: string;
   flow: string;
@@ -124,17 +109,8 @@ const BLOBS: readonly BlobConfig[] = [
     hideMobile: true,
   },
   {
-    // Re-anchored to the top on mobile: the warm orange (#ea580c) bleeds
-    // into iOS Safari's floating URL-bar color-sampling zone when this
-    // blob sits bottom-anchored on phones (the +65vh down-translate plus
-    // 1.2x scale at the 25% keyframe sweep its bounding box through the
-    // bottom 80px of the viewport). Flipping the anchor on narrow screens
-    // keeps the same animation playing in the upper half of the viewport,
-    // so the blob is still part of the composition but never reaches the
-    // URL bar sample area.
     size: "clamp(300px, 46vw, 660px)",
     pos: { bottom: "-10%", left: "-8%" },
-    posMobile: { top: "-10%", left: "-8%" },
     colorIndex: 3,
     morph: "aurora-morph-b 19s ease-in-out infinite -2s",
     flow: "aurora-flow-a 54s linear infinite -28s",
@@ -221,13 +197,6 @@ const STYLESHEET = `
      explicit z-index >= 1 paints above; siblings with no z paint above
      by tree order (since the blobs render first in this component). */
   z-index: 0;
-  /* Anchor offsets come in as inline custom properties so a media query
-     can swap the mobile set in without fighting inline-style specificity.
-     Each blob sets only the sides it uses; the rest are 'auto'. */
-  top: var(--top, auto);
-  right: var(--right, auto);
-  bottom: var(--bottom, auto);
-  left: var(--left, auto);
   width: var(--w);
   height: var(--w);
   background: var(--bg);
@@ -241,22 +210,50 @@ const STYLESHEET = `
     aurora-breathe var(--breathe-dur, 12s) ease-in-out infinite var(--breathe-delay, 0s);
 }
 /* Mobile budget: shrink the blur (the heaviest GPU op) and drop the
-   two smallest blobs that mostly add density rather than silhouette.
-   Blobs that ship a posMobile config override their anchor offsets
-   here, so they can be re-anchored (e.g. bottom -> top) to dodge iOS
-   Safari's URL-bar color-sampling zone without disappearing entirely. */
+   two smallest blobs that mostly add density rather than silhouette. */
 @media (max-width: 640px) {
   .aurora-blob { filter: blur(36px); }
-  .aurora-blob {
-    top: var(--top-m, var(--top, auto));
-    right: var(--right-m, var(--right, auto));
-    bottom: var(--bottom-m, var(--bottom, auto));
-    left: var(--left-m, var(--left, auto));
-  }
   .aurora-blob-mobile-hide { display: none; }
 }
 @media (prefers-reduced-motion: reduce) {
   .aurora-blob { animation: none; }
+}
+/* iOS Safari URL-bar tint shield. The floating bottom URL bar in iOS
+   Safari samples the page color directly underneath it and saturation-
+   boosts it to tint the bar. Any aurora blob that animates through the
+   bottom strip (orange, purple, green all do at some keyframe) gets
+   amplified into a vivid bar tint. This shield is a fixed gradient
+   that fades the page background up over the bottom ~120px so Safari
+   samples a near-solid surface color regardless of where the blobs
+   currently are. Sits above blobs (z:1) but below all page content
+   (header z:50, main/footer z:10), so content stays crisp. Phone-only
+   because iPad/desktop Safari use theme-color, not page sampling. */
+.aurora-url-bar-shield { display: none; }
+@media (max-width: 640px) {
+  .aurora-url-bar-shield {
+    display: block;
+    position: fixed;
+    inset: auto 0 0 0;
+    height: calc(120px + env(safe-area-inset-bottom, 0px));
+    pointer-events: none;
+    z-index: 1;
+    background: linear-gradient(
+      to bottom,
+      rgb(255 255 255 / 0) 0%,
+      rgb(255 255 255 / 0.6) 50%,
+      rgb(255 255 255 / 0.95) 100%
+    );
+  }
+}
+@media (max-width: 640px) and (prefers-color-scheme: dark) {
+  .aurora-url-bar-shield {
+    background: linear-gradient(
+      to bottom,
+      rgb(15 23 42 / 0) 0%,
+      rgb(15 23 42 / 0.6) 50%,
+      rgb(15 23 42 / 0.95) 100%
+    );
+  }
 }
 `;
 
@@ -275,20 +272,8 @@ export function AuroraBackground({
     <div aria-hidden="true" className={`aurora-root ${className ?? ""}`} style={rootStyle}>
       <style precedence="aurora-background">{STYLESHEET}</style>
       {BLOBS.map((b) => {
-        // When posMobile is set it REPLACES pos at <=640px — unspecified
-        // sides resolve to 'auto' (not the desktop value), so a blob can
-        // flip anchors (e.g. bottom -> top) without inheriting the
-        // opposite side from the desktop config.
-        const mobile = b.posMobile ?? b.pos;
         const blobStyle: CSSProperties = {
-          "--top": b.pos.top ?? "auto",
-          "--right": b.pos.right ?? "auto",
-          "--bottom": b.pos.bottom ?? "auto",
-          "--left": b.pos.left ?? "auto",
-          "--top-m": mobile.top ?? "auto",
-          "--right-m": mobile.right ?? "auto",
-          "--bottom-m": mobile.bottom ?? "auto",
-          "--left-m": mobile.left ?? "auto",
+          ...b.pos,
           "--w": b.size,
           "--bg": colors[b.colorIndex],
           "--morph": b.morph,
@@ -304,6 +289,7 @@ export function AuroraBackground({
           />
         );
       })}
+      <div className="aurora-url-bar-shield" />
     </div>
   );
 }

--- a/src/components/AuroraBackground.tsx
+++ b/src/components/AuroraBackground.tsx
@@ -210,50 +210,39 @@ const STYLESHEET = `
     aurora-breathe var(--breathe-dur, 12s) ease-in-out infinite var(--breathe-delay, 0s);
 }
 /* Mobile budget: shrink the blur (the heaviest GPU op) and drop the
-   two smallest blobs that mostly add density rather than silhouette. */
+   two smallest blobs that mostly add density rather than silhouette.
+
+   Mobile bottom boundary: on phones the floating iOS Safari URL bar
+   samples the page color directly behind it. To keep blobs from being
+   sampled, the aurora-root becomes a fixed clipping container that
+   stops short of the URL-bar zone, and blobs switch to position:
+   absolute so they're clipped at the container's bottom edge. The
+   blobs still animate through their full keyframe range -- they just
+   get clipped where they would have crossed into the bar's sample
+   area. No overlay, no fade, no color shift in the visible region. */
 @media (max-width: 640px) {
   .aurora-blob { filter: blur(36px); }
   .aurora-blob-mobile-hide { display: none; }
+  .aurora-root {
+    position: fixed;
+    /* Bottom inset = approximate iOS Safari URL bar height + home
+       indicator safe area. Tuned to the bar's collapsed/expanded
+       range so blobs don't graze the sample zone in either state. */
+    inset: 0 0 calc(72px + env(safe-area-inset-bottom, 0px)) 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
+  }
+  .aurora-blob {
+    /* Inside the fixed clipping container; percentages now resolve
+       against the container, not the viewport. The shift is small
+       (only the bottom inset is removed from the height) so the
+       composition stays visually equivalent to desktop. */
+    position: absolute;
+  }
 }
 @media (prefers-reduced-motion: reduce) {
   .aurora-blob { animation: none; }
-}
-/* iOS Safari URL-bar tint shield. The floating bottom URL bar in iOS
-   Safari samples the page color directly underneath it and saturation-
-   boosts it to tint the bar. Any aurora blob that animates through the
-   bottom strip (orange, purple, green all do at some keyframe) gets
-   amplified into a vivid bar tint. This shield is a fixed gradient
-   that fades the page background up over the bottom ~120px so Safari
-   samples a near-solid surface color regardless of where the blobs
-   currently are. Sits above blobs (z:1) but below all page content
-   (header z:50, main/footer z:10), so content stays crisp. Phone-only
-   because iPad/desktop Safari use theme-color, not page sampling. */
-.aurora-url-bar-shield { display: none; }
-@media (max-width: 640px) {
-  .aurora-url-bar-shield {
-    display: block;
-    position: fixed;
-    inset: auto 0 0 0;
-    height: calc(120px + env(safe-area-inset-bottom, 0px));
-    pointer-events: none;
-    z-index: 1;
-    background: linear-gradient(
-      to bottom,
-      rgb(255 255 255 / 0) 0%,
-      rgb(255 255 255 / 0.6) 50%,
-      rgb(255 255 255 / 0.95) 100%
-    );
-  }
-}
-@media (max-width: 640px) and (prefers-color-scheme: dark) {
-  .aurora-url-bar-shield {
-    background: linear-gradient(
-      to bottom,
-      rgb(15 23 42 / 0) 0%,
-      rgb(15 23 42 / 0.6) 50%,
-      rgb(15 23 42 / 0.95) 100%
-    );
-  }
 }
 `;
 
@@ -289,7 +278,6 @@ export function AuroraBackground({
           />
         );
       })}
-      <div className="aurora-url-bar-shield" />
     </div>
   );
 }

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -100,11 +100,12 @@ export function Layout({ children, onHome, showBack, onPrivacy }: LayoutProps) {
         {children}
       </main>
 
-      {/* Footer bg bumped to ~92% opaque (was 55%) so the orange aurora
-          blob anchored at the bottom-left can't bleed through into iOS
-          Safari's bottom-toolbar tint sampling. `safe-area-inset-bottom`
-          extends the painted area into the home-indicator zone so the
-          toolbar always samples the footer's surface color. */}
+      {/* Footer bg kept ~92% opaque so it reads as a solid surface over
+          the aurora when scrolled into view. iOS Safari URL-bar tint
+          sampling is now handled by the AuroraBackground's bottom shield
+          (works at any scroll position, not just at-end). The
+          `safe-area-inset-bottom` padding still extends the painted area
+          into the home-indicator zone. */}
       <footer
         className="relative z-10 border-t border-slate-200/60 dark:border-dark-border bg-[color-mix(in_oklab,white_92%,transparent)] dark:bg-[color-mix(in_oklab,var(--color-dark-surface)_92%,transparent)] backdrop-blur-md"
         style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -102,10 +102,11 @@ export function Layout({ children, onHome, showBack, onPrivacy }: LayoutProps) {
 
       {/* Footer bg kept ~92% opaque so it reads as a solid surface over
           the aurora when scrolled into view. iOS Safari URL-bar tint
-          sampling is now handled by the AuroraBackground's bottom shield
-          (works at any scroll position, not just at-end). The
-          `safe-area-inset-bottom` padding still extends the painted area
-          into the home-indicator zone. */}
+          sampling is handled inside AuroraBackground itself: on mobile,
+          the aurora-root is a fixed clipping container that stops above
+          the URL bar zone, so no blob ever paints into Safari's sample
+          area. The `safe-area-inset-bottom` padding here still extends
+          the footer's painted area into the home-indicator zone. */}
       <footer
         className="relative z-10 border-t border-slate-200/60 dark:border-dark-border bg-[color-mix(in_oklab,white_92%,transparent)] dark:bg-[color-mix(in_oklab,var(--color-dark-surface)_92%,transparent)] backdrop-blur-md"
         style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}


### PR DESCRIPTION
This pull request refactors how the Aurora background blobs are positioned and clipped on mobile devices, especially to address issues with iOS Safari's URL bar color sampling. The changes simplify the positioning logic, remove the need for mobile-specific position overrides, and introduce a fixed clipping container to prevent blobs from bleeding into the URL bar area. Additionally, related comments and styles are updated for clarity and consistency.

**Mobile positioning and clipping improvements:**

* Removed the `posMobile` property from the `BlobConfig` interface and all related logic, simplifying blob positioning to use a single `pos` object for both desktop and mobile. [[1]](diffhunk://#diff-a75e087153682e4dbebb75cd1924d16011769668b3454e84c68eb33be953fbe3L69-R71) [[2]](diffhunk://#diff-a75e087153682e4dbebb75cd1924d16011769668b3454e84c68eb33be953fbe3L127-L137) [[3]](diffhunk://#diff-a75e087153682e4dbebb75cd1924d16011769668b3454e84c68eb33be953fbe3L278-R265)
* Updated the mobile CSS to make `.aurora-root` a fixed-position clipping container on mobile, preventing blobs from rendering into the iOS Safari URL bar sample area. Blobs now use `position: absolute` inside this container, and the container is inset to avoid the URL bar and home indicator.

**Code and style simplification:**

* Removed custom properties and media query logic for mobile-specific blob anchor offsets, since all blobs now use a unified positioning approach. [[1]](diffhunk://#diff-a75e087153682e4dbebb75cd1924d16011769668b3454e84c68eb33be953fbe3L224-L230) [[2]](diffhunk://#diff-a75e087153682e4dbebb75cd1924d16011769668b3454e84c68eb33be953fbe3L278-R265)

**Documentation and comments:**

* Updated comments in both the Aurora background and the footer to reflect the new approach for handling iOS Safari's URL bar sampling, clarifying that the fixed container now prevents any blob from painting into the sample area. [[1]](diffhunk://#diff-a4d72ac54801a218d7cfd27d169a7724d8c041bba5f6ba18e501670faab655a4L103-R109) [[2]](diffhunk://#diff-a75e087153682e4dbebb75cd1924d16011769668b3454e84c68eb33be953fbe3L245-L256)