### PR TITLE
fix(deps): patch form-data advisory (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,12 +50,5 @@
     "vite-plus": "^0.1.24",
     "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.24"
   },
-  "packageManager": "pnpm@10.32.1",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@^0.1.24",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@^0.1.24",
-      "serialize-javascript": ">=7.0.3"
-    }
-  }
+  "packageManager": "pnpm@10.32.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   vite: npm:@voidzero-dev/vite-plus-core@^0.1.24
   vitest: npm:@voidzero-dev/vite-plus-test@^0.1.24
   serialize-javascript: '>=7.0.3'
+  form-data: '>=4.0.6'
 
 importers:
 
@@ -2820,10 +2821,6 @@ packages:
 
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
-    engines: {node: '>= 6'}
 
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
@@ -5980,7 +5977,7 @@ snapshots:
 
   '@types/node-fetch@2.6.13':
     dependencies:
-      '@types/node': 18.19.130
+      '@types/node': 25.9.3
       form-data: 4.0.6
 
   '@types/node-forge@1.3.14':
@@ -6121,7 +6118,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6602,14 +6599,6 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.4:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.4
-      mime-types: 2.1.35
-
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -6782,7 +6771,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6801,7 +6790,7 @@ snapshots:
       dotenv: 16.4.5
       extend: 3.0.2
       file-type: 21.3.2
-      form-data: 4.0.4
+      form-data: 4.0.6
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# pnpm 10 reads dependency overrides from here (no longer from package.json's
+# "pnpm.overrides", which it silently ignores). vite/vitest are remapped to the
+# Vite+ drop-ins; the rest pin transitive deps past known advisories:
+#   - serialize-javascript >=7.0.3  (XSS, GHSA-76p7-773f-r4q5)
+#   - form-data >=4.0.6             (unsafe boundary, GHSA-hmw2-7cc7-3qxx)
+overrides:
+  vite: "npm:@voidzero-dev/vite-plus-core@^0.1.24"
+  vitest: "npm:@voidzero-dev/vite-plus-test@^0.1.24"
+  serialize-javascript: ">=7.0.3"
+  form-data: ">=4.0.6"


### PR DESCRIPTION
Fixes the failing **Dependency Audit** workflow.

## Security
- Pin **`form-data` >=4.0.6** (GHSA-hmw2-7cc7-3qxx, High / CVSS 8.7). `ibm-cloud-sdk-core` pulled the vulnerable `4.0.4` transitively. `osv-scanner scan --lockfile=pnpm-lock.yaml` → **No issues found**.

## Overrides relocated
- Moved dependency overrides to **`pnpm-workspace.yaml`**. pnpm 10 no longer reads `package.json` `pnpm.overrides` (it was being silently ignored), so the `form-data` pin only takes effect from its supported home. The existing `vite`/`vitest` aliases and `serialize-javascript` pin carried over unchanged.

## Note on Vite+ 0.2.0
I attempted to also upgrade `vite-plus`/`vite-plus-core` to 0.2.0, but **reverted it**: 0.2.0 introduces a native (napi) binding that Cloudflare's build environment fails to install (`Cannot find module '@voidzero-dev/vite-plus-linux-x64-gnu'`), breaking the deploy. 0.1.24 has no native binding and deploys cleanly. Adopting 0.2.0 will need the CF build's native-binding install sorted separately.

## Verification
- `osv-scanner` (no issues), `vp check`, `vp build`, `vp test` (244 pass) all pass on the 0.1.24 toolchain.