### PR TITLE
Release: smart per-page PDF compression

### DIFF
--- a/src/editor/ExportModal.tsx
+++ b/src/editor/ExportModal.tsx
@@ -60,9 +60,9 @@ type Quality = "low" | "medium" | "high";
 type Format = "pdf" | "images" | "contact" | "split" | "text" | "markdown";
 
 const COMPRESS_INFO: Record<Quality, string> = {
-  low: "Sharpest pages, modest size drop (1× render, JPEG 85%).",
-  medium: "Balanced size vs quality — suits most documents (1.5× render, JPEG 70%).",
-  high: "Smallest file, softest pages (2× render, JPEG 50%).",
+  low: "Sharpest pages, modest size drop (2× render, JPEG 82%).",
+  medium: "Balanced size vs quality — suits most documents (1.5× render, JPEG 68%).",
+  high: "Smallest file, softest pages (1× render, JPEG 50%).",
 };
 
 const FORMATS: { value: Format; icon: LucideIcon; label: string; hint: string }[] = [

--- a/src/editor/ExportModal.tsx
+++ b/src/editor/ExportModal.tsx
@@ -601,7 +601,7 @@ export function ExportButton() {
                       <OptionRow
                         icon={Archive}
                         label="Compress"
-                        hint="Shrink by re-rendering pages as images"
+                        hint="Shrink smartly — keep text, re-render image pages"
                         checked={compress}
                         onChange={setCompress}
                       >

--- a/src/editor/ExportModal.tsx
+++ b/src/editor/ExportModal.tsx
@@ -59,10 +59,13 @@ const IMAGE_DPI = 150;
 type Quality = "low" | "medium" | "high";
 type Format = "pdf" | "images" | "contact" | "split" | "text" | "markdown";
 
+// Compression is smart per-page: light text/vector pages are kept lossless
+// (text stays selectable), and scanned / image-heavy pages are re-rendered only
+// when that's actually smaller — so the level below controls those pages' detail.
 const COMPRESS_INFO: Record<Quality, string> = {
-  low: "Sharpest pages, modest size drop (2× render, JPEG 82%).",
-  medium: "Balanced size vs quality — suits most documents (1.5× render, JPEG 68%).",
-  high: "Smallest file, softest pages (1× render, JPEG 50%).",
+  low: "Text pages kept sharp & selectable; image pages at high detail (2×, JPEG 82%).",
+  medium: "Text pages kept selectable; image pages balanced (1.5×, JPEG 68%).",
+  high: "Text pages kept selectable; image pages smallest & softest (1×, JPEG 50%).",
 };
 
 const FORMATS: { value: Format; icon: LucideIcon; label: string; hint: string }[] = [

--- a/src/utils/pdf/transform.ts
+++ b/src/utils/pdf/transform.ts
@@ -3,36 +3,111 @@
  * images-to-PDF, N-up, and crop/uncrop.
  */
 
-import { PDFDocument, PDFName, rgb } from "@pdfme/pdf-lib";
+import {
+  PDFArray,
+  PDFDict,
+  PDFDocument,
+  type PDFPage,
+  PDFName,
+  PDFRawStream,
+  PDFRef,
+  rgb,
+} from "@pdfme/pdf-lib";
 import type { CropMargins } from "../../types.ts";
 import { PDFJS_WASM_URL } from "../pdfjs-config.ts";
 import { clampScaleForCanvas, decodeImageToPngBytes, getPdfJs } from "./raster.ts";
 
 /**
- * Compress a PDF by re-rendering each page as a JPEG image.
+ * Below this lossless byte weight, rasterising a page can't plausibly beat
+ * copying it through (a rasterised Letter page rarely encodes under ~30-90 KB),
+ * so such pages skip the render entirely. Heavier pages get rendered and kept
+ * only if the JPEG actually comes out smaller (see {@link compressPdf}).
+ */
+const COMPRESS_RENDER_GATE_BYTES = 50 * 1024;
+
+/**
+ * Sum the lossless byte weight a page contributes: its content stream(s), the
+ * image/form XObjects it references, and any Type3 font glyph programs
+ * (CharProcs). This is what rasterising would replace, so it's the bar a page's
+ * JPEG must beat to be worth rasterising. Shared resources are counted per page
+ * (a slight over-count), which only biases toward rasterising heavy pages — the
+ * per-page and whole-document guards keep that honest.
+ */
+function pageLosslessWeight(doc: PDFDocument, page: PDFPage): number {
+  const ctx = doc.context;
+  let weight = 0;
+  const seen = new Set<string>();
+  const addStream = (v: unknown): void => {
+    let obj = v;
+    if (v instanceof PDFRef) {
+      if (seen.has(v.tag)) return;
+      seen.add(v.tag);
+      obj = ctx.lookup(v);
+    }
+    if (obj instanceof PDFRawStream) weight += obj.contents.length;
+  };
+  const resolveDict = (dict: PDFDict, key: string): unknown => {
+    const v = dict.get(PDFName.of(key));
+    return v instanceof PDFRef ? ctx.lookup(v) : v;
+  };
+
+  // Content stream(s) — a single stream or an array of them.
+  const contents = resolveDict(page.node, "Contents");
+  if (contents instanceof PDFRawStream) weight += contents.contents.length;
+  else if (contents instanceof PDFArray) for (const e of contents.asArray()) addStream(e);
+
+  const res = resolveDict(page.node, "Resources");
+  if (res instanceof PDFDict) {
+    const xobjects = resolveDict(res, "XObject");
+    if (xobjects instanceof PDFDict) for (const [, v] of xobjects.entries()) addStream(v);
+    const fonts = resolveDict(res, "Font");
+    if (fonts instanceof PDFDict) {
+      for (const [, fv] of fonts.entries()) {
+        const fontDict = fv instanceof PDFRef ? ctx.lookup(fv) : fv;
+        if (fontDict instanceof PDFDict) {
+          const charProcs = resolveDict(fontDict, "CharProcs");
+          if (charProcs instanceof PDFDict) for (const [, pv] of charProcs.entries()) addStream(pv);
+        }
+      }
+    }
+  }
+  return weight;
+}
+
+/**
+ * Compress a PDF, picking the best strategy *per page* by measured bytes:
  *
- * This is a lossy compression strategy: every page is rasterised via PDF.js
- * at a configurable scale, converted to JPEG at a given quality, and then
- * re-embedded into a brand-new PDF document. Vector content and selectable
- * text are lost, but the file size can be dramatically reduced.
+ *  - **Light pages** (lossless weight under {@link COMPRESS_RENDER_GATE_BYTES})
+ *    are copied through losslessly without even rendering — rasterising them
+ *    couldn't win. Selectable text is preserved.
+ *  - **Heavy pages** (scans, photo pages, Type3-font / vector-dense pages) are
+ *    rendered to a JPEG and kept **only if that JPEG is smaller** than the
+ *    page's lossless weight; otherwise the page is copied through too. This is
+ *    the big win on scanned and image-heavy documents.
  *
- * The render `scale` is pure supersampling — the output page is always sized
- * at 1.0× (`origViewport` below), so `scale` only sets how many pixels the JPEG
- * carries. More pixels → bigger JPEG. Higher compression therefore renders at a
- * *lower* scale (fewer pixels, also faster + less memory), not a higher one.
+ * The structural rebuild itself (a single `copyPages` into a fresh doc, saved
+ * with object streams) drops unreachable objects and dedupes shared resources,
+ * reclaiming ~15-25% on typical text PDFs with no quality loss.
  *
- * Quality presets:
- *   - `low`    → scale 2.0×, JPEG quality 82% (sharpest pages, lightest drop)
+ * The render `scale` for rasterised pages is pure supersampling — the output
+ * page is sized at 1.0× (`origViewport`), so `scale` only sets the JPEG's pixel
+ * count. More pixels → bigger JPEG. Higher compression therefore renders at a
+ * *lower* scale (fewer pixels, also faster + less memory). The level also tunes
+ * how aggressively pages rasterise: bigger JPEGs at `low` clear fewer pages'
+ * weight bars, so more text is kept; smaller JPEGs at `high` rasterise more.
+ *
+ * Quality presets (apply to rasterised pages):
+ *   - `low`    → scale 2.0×, JPEG quality 82% (sharpest, lightest drop)
  *   - `medium` → scale 1.5×, JPEG quality 68% (balanced)
- *   - `high`   → scale 1.0×, JPEG quality 50% (smallest file, softest pages)
+ *   - `high`   → scale 1.0×, JPEG quality 50% (smallest, softest)
  *
- * Rasterising a text/vector PDF can produce a *larger* file than the original
- * at any preset, so we keep the smaller of (original, rasterised) and never
- * hand back an inflated "compressed" file.
+ * As a final guard the result is compared against the source: if the rebuild
+ * didn't actually shrink the file (already-optimised input), the original bytes
+ * are returned untouched rather than a larger "compressed" file.
  *
  * @param file - The PDF file to compress.
  * @param quality - Compression preset: "low", "medium", or "high".
- * @returns Compressed PDF bytes.
+ * @returns Compressed PDF bytes (or the original bytes if no gain was possible).
  */
 export async function compressPdf(
   file: File,
@@ -48,69 +123,105 @@ export async function compressPdf(
   const { scale, jpegQuality } = qualitySettings[quality];
 
   const pdfjsLib = await getPdfJs();
-  const arrayBuffer = await file.arrayBuffer();
-  const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer, wasmUrl: PDFJS_WASM_URL });
+  const loadingTask = pdfjsLib.getDocument({
+    data: new Uint8Array(await file.arrayBuffer()),
+    wasmUrl: PDFJS_WASM_URL,
+  });
   const sourcePdf = await loadingTask.promise;
+  // Separate pdf-lib parse (its own buffer) for the lossless copy path + weight
+  // analysis — the PDF.js worker may detach the buffer it was handed.
+  const srcLib = await PDFDocument.load(new Uint8Array(await file.arrayBuffer()), {
+    updateMetadata: false,
+    throwOnInvalidObject: false,
+    ignoreEncryption: true,
+  });
   const newPdf = await PDFDocument.create();
+  const total = sourcePdf.numPages;
+  const srcPages = srcLib.getPages();
+
+  // Render a single source page to JPEG bytes at the active preset; null if the
+  // page can't be acquired. Releases its canvas before returning.
+  const renderPageJpeg = async (pageNum: number): Promise<Uint8Array> => {
+    const page = await sourcePdf.getPage(pageNum);
+    // Clamp the render scale to the platform canvas ceiling (mobile ~4096
+    // px/side); a large page would otherwise render blank. Output size uses
+    // origViewport below, so this only affects fidelity.
+    const base = page.getViewport({ scale });
+    const safeScale = clampScaleForCanvas(base.width, base.height, scale);
+    const viewport = page.getViewport({ scale: safeScale });
+
+    const canvas = document.createElement("canvas");
+    canvas.width = viewport.width;
+    canvas.height = viewport.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error(`Failed to acquire 2D canvas context for page ${pageNum}`);
+
+    await page.render({ canvasContext: ctx, viewport, canvas }).promise;
+    // Convert to JPEG via toBlob (avoids the overhead of a data-URL round-trip).
+    const jpegBytes = await new Promise<Uint8Array>((resolve, reject) => {
+      canvas.toBlob(
+        (blob) => {
+          if (!blob) return reject(new Error("Canvas toBlob returned null"));
+          blob.arrayBuffer().then((ab) => resolve(new Uint8Array(ab)), reject);
+        },
+        "image/jpeg",
+        jpegQuality,
+      );
+    });
+    canvas.width = 0; // release bitmap memory
+    canvas.height = 0;
+    return jpegBytes;
+  };
 
   try {
-    for (let i = 1; i <= sourcePdf.numPages; i++) {
-      const page = await sourcePdf.getPage(i);
-      // Clamp the render scale to the platform canvas ceiling (mobile ~4096
-      // px/side); a large page would otherwise render blank → a blank output
-      // page. Output size uses origViewport below, so this only affects fidelity.
-      const base = page.getViewport({ scale });
-      const safeScale = clampScaleForCanvas(base.width, base.height, scale);
-      const viewport = page.getViewport({ scale: safeScale });
+    // --- Phase 1: decide per page — rasterise only when it measurably wins. ---
+    // A light page is copied losslessly without rendering. A heavy page is
+    // rendered and rasterised only if the JPEG beats its lossless weight.
+    const rasterJpeg = new Map<number, Uint8Array>(); // 0-based page index → JPEG
+    for (let i = 0; i < total; i++) {
+      const weight = pageLosslessWeight(srcLib, srcPages[i]);
+      if (weight >= COMPRESS_RENDER_GATE_BYTES) {
+        const jpeg = await renderPageJpeg(i + 1);
+        if (jpeg.byteLength < weight) rasterJpeg.set(i, jpeg);
+      }
+    }
 
-      const canvas = document.createElement("canvas");
-      canvas.width = viewport.width;
-      canvas.height = viewport.height;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) throw new Error(`Failed to acquire 2D canvas context for page ${i}`);
+    // --- Phase 2: copy ALL lossless pages in a SINGLE copyPages call. ---
+    // One call dedupes shared resources (fonts) and drops unreachable objects;
+    // copying per-page instead re-embeds shared fonts and bloats the output 4-5×.
+    const losslessIdx: number[] = [];
+    for (let i = 0; i < total; i++) if (!rasterJpeg.has(i)) losslessIdx.push(i);
+    const copied = losslessIdx.length ? await newPdf.copyPages(srcLib, losslessIdx) : [];
+    const copiedByIndex = new Map<number, (typeof copied)[number]>();
+    losslessIdx.forEach((idx, k) => copiedByIndex.set(idx, copied[k]));
 
-      await page.render({ canvasContext: ctx, viewport, canvas }).promise;
-
-      // Convert to JPEG via toBlob (avoids the overhead of a data-URL round-trip)
-      const jpegBytes = await new Promise<Uint8Array>((resolve, reject) => {
-        canvas.toBlob(
-          (blob) => {
-            if (!blob) return reject(new Error("Canvas toBlob returned null"));
-            blob.arrayBuffer().then((ab) => resolve(new Uint8Array(ab)), reject);
-          },
-          "image/jpeg",
-          jpegQuality,
-        );
-      });
-
-      // Release canvas bitmap memory
-      canvas.width = 0;
-      canvas.height = 0;
-
-      const image = await newPdf.embedJpg(jpegBytes);
-
-      // Use original page dimensions (in PDF points)
-      const origViewport = page.getViewport({ scale: 1.0 });
-      const newPage = newPdf.addPage([origViewport.width, origViewport.height]);
-      newPage.drawImage(image, {
-        x: 0,
-        y: 0,
-        width: origViewport.width,
-        height: origViewport.height,
-      });
-
-      onProgress?.(i, sourcePdf.numPages);
+    // --- Phase 3: assemble the output in original page order. ---
+    for (let i = 0; i < total; i++) {
+      const lossless = copiedByIndex.get(i);
+      if (lossless) {
+        newPdf.addPage(lossless);
+      } else {
+        const jpeg = rasterJpeg.get(i);
+        if (!jpeg) throw new Error(`Missing rasterised page ${i + 1}`);
+        const image = await newPdf.embedJpg(jpeg);
+        // Draw into a page sized at the original dimensions (in PDF points).
+        const origViewport = (await sourcePdf.getPage(i + 1)).getViewport({ scale: 1.0 });
+        const newPage = newPdf.addPage([origViewport.width, origViewport.height]);
+        newPage.drawImage(image, {
+          x: 0,
+          y: 0,
+          width: origViewport.width,
+          height: origViewport.height,
+        });
+      }
+      onProgress?.(i + 1, total);
       await new Promise((r) => setTimeout(r, 0));
     }
 
-    const compressed = await newPdf.save({
-      useObjectStreams: true,
-    });
+    const compressed = await newPdf.save({ useObjectStreams: true });
 
-    // Rasterising a text/vector PDF can weigh more than the original. If we
-    // didn't actually shrink it, return the source bytes untouched rather than
-    // hand back a bigger "compressed" file. Re-read from the File — the
-    // arrayBuffer above may have been detached by the PDF.js worker.
+    // If the rebuild didn't actually shrink the file (already-optimised input),
+    // return the source bytes untouched rather than a larger "compressed" file.
     if (compressed.byteLength >= file.size) {
       return new Uint8Array(await file.arrayBuffer());
     }

--- a/src/utils/pdf/transform.ts
+++ b/src/utils/pdf/transform.ts
@@ -16,10 +16,19 @@ import { clampScaleForCanvas, decodeImageToPngBytes, getPdfJs } from "./raster.t
  * re-embedded into a brand-new PDF document. Vector content and selectable
  * text are lost, but the file size can be dramatically reduced.
  *
+ * The render `scale` is pure supersampling — the output page is always sized
+ * at 1.0× (`origViewport` below), so `scale` only sets how many pixels the JPEG
+ * carries. More pixels → bigger JPEG. Higher compression therefore renders at a
+ * *lower* scale (fewer pixels, also faster + less memory), not a higher one.
+ *
  * Quality presets:
- *   - `low`    → scale 1.0×, JPEG quality 85% (lightest compression)
- *   - `medium` → scale 1.5×, JPEG quality 70% (balanced)
- *   - `high`   → scale 2.0×, JPEG quality 50% (maximum compression)
+ *   - `low`    → scale 2.0×, JPEG quality 82% (sharpest pages, lightest drop)
+ *   - `medium` → scale 1.5×, JPEG quality 68% (balanced)
+ *   - `high`   → scale 1.0×, JPEG quality 50% (smallest file, softest pages)
+ *
+ * Rasterising a text/vector PDF can produce a *larger* file than the original
+ * at any preset, so we keep the smaller of (original, rasterised) and never
+ * hand back an inflated "compressed" file.
  *
  * @param file - The PDF file to compress.
  * @param quality - Compression preset: "low", "medium", or "high".
@@ -31,9 +40,9 @@ export async function compressPdf(
   onProgress?: (rendered: number, total: number) => void,
 ): Promise<Uint8Array> {
   const qualitySettings = {
-    low: { scale: 1.0, jpegQuality: 0.85 },
-    medium: { scale: 1.5, jpegQuality: 0.7 },
-    high: { scale: 2.0, jpegQuality: 0.5 },
+    low: { scale: 2.0, jpegQuality: 0.82 },
+    medium: { scale: 1.5, jpegQuality: 0.68 },
+    high: { scale: 1.0, jpegQuality: 0.5 },
   };
 
   const { scale, jpegQuality } = qualitySettings[quality];
@@ -94,9 +103,18 @@ export async function compressPdf(
       await new Promise((r) => setTimeout(r, 0));
     }
 
-    return await newPdf.save({
+    const compressed = await newPdf.save({
       useObjectStreams: true,
     });
+
+    // Rasterising a text/vector PDF can weigh more than the original. If we
+    // didn't actually shrink it, return the source bytes untouched rather than
+    // hand back a bigger "compressed" file. Re-read from the File — the
+    // arrayBuffer above may have been detached by the PDF.js worker.
+    if (compressed.byteLength >= file.size) {
+      return new Uint8Array(await file.arrayBuffer());
+    }
+    return compressed;
   } finally {
     // Always release the PDF.js document + worker session, even on a mid-page throw.
     void loadingTask.destroy();

--- a/tests/e2e/compress.e2e.ts
+++ b/tests/e2e/compress.e2e.ts
@@ -1,14 +1,20 @@
 /**
- * Regression smoke for the Compress tool (compressPdf in src/utils/pdf/transform.ts).
+ * Regression smoke for the smart Compress tool (compressPdf in
+ * src/utils/pdf/transform.ts).
  *
- * Guards the two bugs fixed in this area:
- *   1. The render-scale axis was inverted — "high / smallest file" rendered at
- *      2× (4× the pixels of "low"), so it routinely produced a LARGER + slower
- *      result than "low". Corrected so more compression = lower render scale.
- *      Assert: high <= medium <= low in output size for an image-heavy PDF.
- *   2. No size guard — rasterising a text/vector PDF produced a bigger file than
- *      the original and handed it back as "compressed". Now we keep the smaller
- *      of (original, rasterised). Assert: no preset ever exceeds the original.
+ * compressPdf picks the best strategy per page by measured bytes: light
+ * text/vector pages are copied through losslessly (selectable text preserved,
+ * ~15-25% structural shrink), while heavy pages (scans, photo pages, Type3 /
+ * vector-dense pages) are rasterised to a JPEG and kept only when that's
+ * actually smaller. A final guard returns the original if nothing shrank.
+ *
+ * This guards:
+ *   1. Size guard — no preset ever yields a file larger than the original.
+ *   2. Monotonicity — higher compression never weighs more than lower.
+ *   3. Text preservation — text-dominant PDFs keep (nearly) all their
+ *      selectable text AND still shrink (the lossless structural win), instead
+ *      of being rasterised to image-only as the old whole-doc rasteriser did.
+ *   4. Image win — an image/Type3-heavy PDF compresses substantially at high.
  *
  * Calls compressPdf directly through the Vite dev module graph (real browser
  * canvas + PDF.js), rather than driving the editor UI.
@@ -27,9 +33,16 @@ const CHROME_PATH =
   process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 const USER_DATA_DIR = resolve(import.meta.dirname, "../.puppeteer-profile-editor");
 
-const FIXTURES = ["sample.pdf", "multipage.pdf", "The Complete Generative AI Leader.pdf"];
 type Quality = "low" | "medium" | "high";
 const QUALITIES: Quality[] = ["low", "medium", "high"];
+
+// `textDominant`: text-heavy PDFs that must stay selectable and still shrink.
+// `imageWin`: heavy (Type3-font) PDF where rasterising should win big at high.
+const FIXTURES: { name: string; textDominant: boolean; imageWin: boolean }[] = [
+  { name: "multipage.pdf", textDominant: true, imageWin: false },
+  { name: "The Complete Generative AI Leader.pdf", textDominant: true, imageWin: false },
+  { name: "sample.pdf", textDominant: false, imageWin: true },
+];
 
 function fail(msg: string): never {
   console.error(`✗ ${msg}`);
@@ -41,6 +54,8 @@ function kb(n: number): string {
   return `${(n / 1024).toFixed(1)} KB`;
 }
 
+type Result = { size: number; textLen: number };
+
 async function main() {
   const browser = await launch({
     executablePath: CHROME_PATH,
@@ -51,68 +66,103 @@ async function main() {
   const page = await browser.newPage();
   const errors: string[] = [];
   try {
-    page.setDefaultTimeout(60_000);
+    page.setDefaultTimeout(90_000);
     page.on("console", (m) => m.type() === "error" && errors.push(m.text()));
     page.on("pageerror", (e: unknown) => errors.push(String(e instanceof Error ? e.message : e)));
 
     await page.goto(DEV_URL, { waitUntil: "networkidle2" });
 
     let allOk = true;
-    for (const name of FIXTURES) {
-      const path = resolve(import.meta.dirname, "../fixtures", name);
+    for (const fx of FIXTURES) {
+      const path = resolve(import.meta.dirname, "../fixtures", fx.name);
       if (!existsSync(path)) fail(`Fixture not found at ${path}.`);
       const bytes = readFileSync(path);
       const original = bytes.byteLength;
 
-      // Push the bytes into the page and call compressPdf via the dev module
-      // graph for each preset.
-      const sizes = (await page.evaluate(
+      // In the page: compress at each preset and measure output size + the
+      // total selectable-text length of the compressed result (via PDF.js).
+      const { origTextLen, results } = (await page.evaluate(
         async (b64: string, fileName: string, qualities: Quality[]) => {
           const bin = atob(b64);
           const u8 = new Uint8Array(bin.length);
           for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
-          // Specifier kept in a variable so tsc doesn't try to resolve this
-          // browser-only dev-server URL; Vite serves it from the module graph.
-          const spec = "/src/utils/pdf-operations.ts";
-          const mod = await import(/* @vite-ignore */ spec);
-          const out: Record<string, number> = {};
+
+          const opsSpec = "/src/utils/pdf-operations.ts";
+          const rasterSpec = "/src/utils/pdf/raster.ts";
+          const ops = await import(/* @vite-ignore */ opsSpec);
+          const { getPdfJs } = await import(/* @vite-ignore */ rasterSpec);
+          const pdfjsLib = await getPdfJs();
+
+          const textLenOf = async (data: Uint8Array): Promise<number> => {
+            const task = pdfjsLib.getDocument({ data: data.slice(0) });
+            const doc = await task.promise;
+            let len = 0;
+            for (let i = 1; i <= doc.numPages; i++) {
+              const tc = await (await doc.getPage(i)).getTextContent();
+              for (const it of tc.items) if ("str" in it) len += it.str.length;
+            }
+            await task.destroy();
+            return len;
+          };
+
+          const origTextLen = await textLenOf(u8);
+          const results: Record<string, { size: number; textLen: number }> = {};
           for (const q of qualities) {
             const file = new File([u8], fileName, { type: "application/pdf" });
-            const result = await mod.compressPdf(file, q);
-            out[q] = result.byteLength;
+            const out = await ops.compressPdf(file, q);
+            results[q] = { size: out.byteLength, textLen: await textLenOf(out) };
           }
-          return out;
+          return { origTextLen, results };
         },
         bytes.toString("base64"),
-        name,
+        fx.name,
         QUALITIES,
-      )) as Record<Quality, number>;
+      )) as { origTextLen: number; results: Record<Quality, Result> };
 
-      console.log(`\n${name}  (original ${kb(original)})`);
+      console.log(`\n${fx.name}  (original ${kb(original)}, ${origTextLen} chars)`);
       for (const q of QUALITIES) {
-        const pct = (((original - sizes[q]) / original) * 100).toFixed(1);
-        console.log(`  ${q.padEnd(7)} → ${kb(sizes[q]).padStart(11)}  (${pct}% smaller)`);
+        const r = results[q];
+        const pct = (((original - r.size) / original) * 100).toFixed(1);
+        const txt = origTextLen ? ((100 * r.textLen) / origTextLen).toFixed(0) : "—";
+        console.log(
+          `  ${q.padEnd(7)} → ${kb(r.size).padStart(11)}  (${pct}% smaller, text ${txt}%)`,
+        );
       }
 
-      // Assertion 1: size guard — no preset may exceed the original.
+      // 1. Size guard — no preset may exceed the original.
       for (const q of QUALITIES) {
-        if (sizes[q] > original) {
-          console.error(
-            `  ✗ ${q} (${kb(sizes[q])}) exceeds original (${kb(original)}) — guard failed`,
-          );
+        if (results[q].size > original) {
+          console.error(`  ✗ ${q} (${kb(results[q].size)}) exceeds original — guard failed`);
           allOk = false;
         }
       }
-      // Assertion 2: scale axis correct — more compression never weighs more.
-      // (Equality is allowed: the guard can return the original for both.)
-      if (sizes.high > sizes.low) {
-        console.error(
-          `  ✗ high (${kb(sizes.high)}) > low (${kb(sizes.low)}) — axis still inverted`,
-        );
+      // 2. Monotonicity — more compression never weighs more.
+      if (results.high.size > results.low.size) {
+        console.error(`  ✗ high > low — axis inverted`);
         allOk = false;
       }
-      if (sizes.medium > sizes.low) {
-        console.error(`  ✗ medium (${kb(sizes.medium)}) > low (${kb(sizes.low)}) — axis inverted`);
+      if (results.medium.size > results.low.size) {
+        console.error(`  ✗ medium > low — axis inverted`);
+        allOk = false;
+      }
+      // 3. Text-dominant PDFs must stay (nearly) fully selectable AND shrink.
+      if (fx.textDominant) {
+        for (const q of QUALITIES) {
+          if (results[q].textLen < origTextLen * 0.95) {
+            console.error(
+              `  ✗ ${q} kept only ${results[q].textLen}/${origTextLen} chars — text not preserved`,
+            );
+            allOk = false;
+          }
+        }
+        if (results.medium.size >= original) {
+          console.error(`  ✗ text PDF did not shrink at medium (lossless win missing)`);
+          allOk = false;
+        }
+      }
+      // 4. Image/Type3-heavy PDFs should compress substantially at high.
+      if (fx.imageWin && results.high.size > original * 0.6) {
+        console.error(`  ✗ image-heavy PDF only reached ${kb(results.high.size)} at high`);
         allOk = false;
       }
     }
@@ -123,7 +173,7 @@ async function main() {
       process.exit(1);
     }
     if (!allOk) fail("Compress smoke failed — see assertions above.");
-    console.log("\n✓ Compress smoke passed — size guard holds, scale axis correct.");
+    console.log("\n✓ Compress smoke passed — guard holds, text preserved, images crushed.");
   } catch (e) {
     console.error(`✗ Compress smoke failed: ${e instanceof Error ? e.message : String(e)}`);
     process.exitCode = 1;

--- a/tests/e2e/compress.e2e.ts
+++ b/tests/e2e/compress.e2e.ts
@@ -37,11 +37,13 @@ type Quality = "low" | "medium" | "high";
 const QUALITIES: Quality[] = ["low", "medium", "high"];
 
 // `textDominant`: text-heavy PDFs that must stay selectable and still shrink.
-// `imageWin`: heavy (Type3-font) PDF where rasterising should win big at high.
+// `imageWin`: image/Type3-heavy PDF where rasterising should win big at high.
 const FIXTURES: { name: string; textDominant: boolean; imageWin: boolean }[] = [
   { name: "multipage.pdf", textDominant: true, imageWin: false },
   { name: "The Complete Generative AI Leader.pdf", textDominant: true, imageWin: false },
   { name: "sample.pdf", textDominant: false, imageWin: true },
+  // A genuine multi-page scanned document (Acrobat Distiller, ~200 chars).
+  { name: "Sample Scanned Doc.pdf", textDominant: false, imageWin: true },
 ];
 
 function fail(msg: string): never {

--- a/tests/e2e/compress.e2e.ts
+++ b/tests/e2e/compress.e2e.ts
@@ -1,0 +1,134 @@
+/**
+ * Regression smoke for the Compress tool (compressPdf in src/utils/pdf/transform.ts).
+ *
+ * Guards the two bugs fixed in this area:
+ *   1. The render-scale axis was inverted — "high / smallest file" rendered at
+ *      2× (4× the pixels of "low"), so it routinely produced a LARGER + slower
+ *      result than "low". Corrected so more compression = lower render scale.
+ *      Assert: high <= medium <= low in output size for an image-heavy PDF.
+ *   2. No size guard — rasterising a text/vector PDF produced a bigger file than
+ *      the original and handed it back as "compressed". Now we keep the smaller
+ *      of (original, rasterised). Assert: no preset ever exceeds the original.
+ *
+ * Calls compressPdf directly through the Vite dev module graph (real browser
+ * canvas + PDF.js), rather than driving the editor UI.
+ *
+ * Requirements: Chrome at CHROME_PATH and the dev server at localhost:5173
+ * (`vp dev`). Fixtures: tests/fixtures/*.pdf.
+ *
+ * Run:  node --experimental-strip-types tests/e2e/compress.e2e.ts
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { launch } from "puppeteer-core";
+
+const DEV_URL = process.env.E2E_URL ?? "http://localhost:5173";
+const CHROME_PATH =
+  process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const USER_DATA_DIR = resolve(import.meta.dirname, "../.puppeteer-profile-editor");
+
+const FIXTURES = ["sample.pdf", "multipage.pdf", "The Complete Generative AI Leader.pdf"];
+type Quality = "low" | "medium" | "high";
+const QUALITIES: Quality[] = ["low", "medium", "high"];
+
+function fail(msg: string): never {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+if (!existsSync(CHROME_PATH)) fail(`Chrome not found at ${CHROME_PATH} (set CHROME_PATH).`);
+
+function kb(n: number): string {
+  return `${(n / 1024).toFixed(1)} KB`;
+}
+
+async function main() {
+  const browser = await launch({
+    executablePath: CHROME_PATH,
+    userDataDir: USER_DATA_DIR,
+    headless: true,
+    defaultViewport: { width: 1280, height: 900 },
+  });
+  const page = await browser.newPage();
+  const errors: string[] = [];
+  try {
+    page.setDefaultTimeout(60_000);
+    page.on("console", (m) => m.type() === "error" && errors.push(m.text()));
+    page.on("pageerror", (e: unknown) => errors.push(String(e instanceof Error ? e.message : e)));
+
+    await page.goto(DEV_URL, { waitUntil: "networkidle2" });
+
+    let allOk = true;
+    for (const name of FIXTURES) {
+      const path = resolve(import.meta.dirname, "../fixtures", name);
+      if (!existsSync(path)) fail(`Fixture not found at ${path}.`);
+      const bytes = readFileSync(path);
+      const original = bytes.byteLength;
+
+      // Push the bytes into the page and call compressPdf via the dev module
+      // graph for each preset.
+      const sizes = (await page.evaluate(
+        async (b64: string, fileName: string, qualities: Quality[]) => {
+          const bin = atob(b64);
+          const u8 = new Uint8Array(bin.length);
+          for (let i = 0; i < bin.length; i++) u8[i] = bin.charCodeAt(i);
+          // Specifier kept in a variable so tsc doesn't try to resolve this
+          // browser-only dev-server URL; Vite serves it from the module graph.
+          const spec = "/src/utils/pdf-operations.ts";
+          const mod = await import(/* @vite-ignore */ spec);
+          const out: Record<string, number> = {};
+          for (const q of qualities) {
+            const file = new File([u8], fileName, { type: "application/pdf" });
+            const result = await mod.compressPdf(file, q);
+            out[q] = result.byteLength;
+          }
+          return out;
+        },
+        bytes.toString("base64"),
+        name,
+        QUALITIES,
+      )) as Record<Quality, number>;
+
+      console.log(`\n${name}  (original ${kb(original)})`);
+      for (const q of QUALITIES) {
+        const pct = (((original - sizes[q]) / original) * 100).toFixed(1);
+        console.log(`  ${q.padEnd(7)} → ${kb(sizes[q]).padStart(11)}  (${pct}% smaller)`);
+      }
+
+      // Assertion 1: size guard — no preset may exceed the original.
+      for (const q of QUALITIES) {
+        if (sizes[q] > original) {
+          console.error(
+            `  ✗ ${q} (${kb(sizes[q])}) exceeds original (${kb(original)}) — guard failed`,
+          );
+          allOk = false;
+        }
+      }
+      // Assertion 2: scale axis correct — more compression never weighs more.
+      // (Equality is allowed: the guard can return the original for both.)
+      if (sizes.high > sizes.low) {
+        console.error(
+          `  ✗ high (${kb(sizes.high)}) > low (${kb(sizes.low)}) — axis still inverted`,
+        );
+        allOk = false;
+      }
+      if (sizes.medium > sizes.low) {
+        console.error(`  ✗ medium (${kb(sizes.medium)}) > low (${kb(sizes.low)}) — axis inverted`);
+        allOk = false;
+      }
+    }
+
+    if (errors.length > 0) {
+      console.error("\n✗ Console/page errors during compress smoke:");
+      for (const e of errors) console.error(`   ${e}`);
+      process.exit(1);
+    }
+    if (!allOk) fail("Compress smoke failed — see assertions above.");
+    console.log("\n✓ Compress smoke passed — size guard holds, scale axis correct.");
+  } catch (e) {
+    console.error(`✗ Compress smoke failed: ${e instanceof Error ? e.message : String(e)}`);
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+}
+void main();


### PR DESCRIPTION
Promotes the smart compression work from `dev` to `main`.

## Summary

Reworks the Compress tool into a **smart per-page** compressor that picks the best method by measured bytes — preserving selectable text on text PDFs while still crushing scans and image-heavy pages.

- **Inverted render-scale axis fixed** — max compression no longer rendered at the highest resolution (which produced the largest, slowest result).
- **Smart per-page routing** — light pages copied losslessly (text preserved); heavier pages rasterised only when that's actually smaller.
- **Lossless structural win** — single `copyPages` rebuild + object streams (~15–25% on text PDFs, no quality loss).
- **Size guard** — returns the original if nothing shrank.

## Results (measured, real browser)

| Fixture | Light / Balanced / Max | Text kept |
|---|---|---|
| multipage.pdf (text) | −22% all levels | 100% |
| AI Leader.pdf (text) | −25% all levels | 100% |
| sample.pdf (Type3-rich) | −16% / −38% / −75% | 67% → 0% |
| Sample Scanned Doc.pdf (scan) | −7.9% / −51% / −81% | 78% → 0% |

## Testing

- `vp check`, `vp test` (290 passed), `vp build` — all green.
- `tests/e2e/compress.e2e.ts` (real-browser) asserts size guard, monotonicity, text preservation, and image-win across 4 fixtures.
- Visually confirmed on desktop and mobile layouts; Max-compressed scan renders legibly.

Merges via #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)