### PR TITLE
Editor: drag-resize placement, signatures, annotate icons + audit pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@
 
 ## ✨ What it does
 
-Drop a PDF and it opens in a single, canvas-based **editor** — a Photoshop-like workspace for one document at a time:
+Drop a PDF and it opens in a single, canvas-based **editor** — a Photoshop-like workspace for one document at a time. **22 editor tools and 7 standalone utilities** cover everything from a quick tick on a printed form to redaction, OCR, and on-device AI:
 
-- **✏️ Annotate & sign** — draw, highlight, shapes, text, signatures, fill & flatten forms (or auto-fill flat printed ones)
-- **📄 Pages** — reorder, rotate, delete, crop (auto-trim & straighten), N-up & booklet, OCR, plus split / extract / contact-sheet on export
+- **✏️ Annotate & sign** — draw, highlight, shapes, text, form-filling icons (tick / cross / dot / circle), signatures, fill & flatten forms (or auto-fill flat printed ones)
+- **📄 Pages** — reorder, rotate, delete, crop (auto-trim & straighten), strip repeating headers/footers, N-up & booklet, OCR, plus split / extract / contact-sheet on export
 - **🔒 Privacy** — redact (burned into the page), select or find & box text, erase regions (fill / blend / pixelate), scrub hidden data, edit or strip metadata
-- **🏷️ Stamps & numbering** — watermarks (with dynamic date/page tokens), QR & barcode stamps, page numbers, headers & footers, Bates numbering, bookmarks
+- **🏷️ Stamps & numbering** — watermarks (with dynamic date/page tokens), QR & barcode stamps, page numbers, headers & footers, Bates numbering, bookmarks, file attachments
 
 Export to PDF, images (ZIP), a contact sheet, or split pages — with optional compress / grayscale / flatten / repair / strip-metadata.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@langchain/core": "^1.2.0",
     "@langchain/langgraph": "^1.4.4",
     "@llamaindex/liteparse-wasm": "^2.1.1",
-    "@pdfme/pdf-lib": "^6.1.9",
+    "@pdfme/pdf-lib": "^6.1.10",
     "jszip": "^3.10.1",
     "lucide-react": "^1.21.0",
     "motion": "^12.40.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       '@pdfme/pdf-lib':
-        specifier: ^6.1.9
-        version: 6.1.9
+        specifier: ^6.1.10
+        version: 6.1.10
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
@@ -1764,8 +1764,8 @@ packages:
   '@pdf-lib/upng@1.0.1':
     resolution: {integrity: sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==}
 
-  '@pdfme/pdf-lib@6.1.9':
-    resolution: {integrity: sha512-vq252zQWfq6oa9lDYnv+ZGJFWcX+5hW+tKqvsg32Is4LQHlSpld55aU/z5/PI8ATpMSJ8QyykuX3+EkGCZPWUA==}
+  '@pdfme/pdf-lib@6.1.10':
+    resolution: {integrity: sha512-tPdWVuqEq4kvIu57sPKxMab/uC2dP4GFUKjO7wL1OGxFu0KQz+j5byxwY8Pkh7AlVtnYUxvm5tHE0NtpmJmeBw==}
 
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
@@ -2467,8 +2467,8 @@ packages:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.4:
+    resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -4518,7 +4518,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -5699,7 +5699,7 @@ snapshots:
     dependencies:
       pako: 1.0.11
 
-  '@pdfme/pdf-lib@6.1.9':
+  '@pdfme/pdf-lib@6.1.10':
     dependencies:
       '@pdf-lib/standard-fonts': 1.0.0
       '@pdf-lib/upng': 1.0.1
@@ -6234,13 +6234,13 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  browserslist@4.28.2:
+  browserslist@4.28.4:
     dependencies:
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
       electron-to-chromium: 1.5.376
       node-releases: 2.0.48
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -6340,7 +6340,7 @@ snapshots:
 
   core-js-compat@3.49.0:
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
 
   core-util-is@1.0.3: {}
 
@@ -8435,9 +8435,9 @@ snapshots:
 
   upath@1.2.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.2.3(browserslist@4.28.4):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.4
       escalade: 3.2.0
       picocolors: 1.1.1
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,18 @@ function LoadingSpinner() {
   );
 }
 
+/** Loading fallback for the editor route. Deliberately mirrors EditorShell's own
+ *  centred "Opening PDF…" spinner (same size, same viewport-centred position) so
+ *  the chunk-load → PDF-parse handoff shows ONE loader in ONE place — never a
+ *  top-anchored spinner followed by a centred one. */
+function EditorLoadingFallback() {
+  return (
+    <div className="fixed inset-0 z-100 flex items-center justify-center bg-slate-50 dark:bg-dark-bg">
+      <div className="h-8 w-8 animate-spin rounded-full border-3 border-primary-200 border-t-primary-600" />
+    </div>
+  );
+}
+
 // ── ToolView ─────────────────────────────────────────────────────
 
 interface ToolViewProps {
@@ -254,7 +266,7 @@ function HomeScreen({ onSelectTool, onOpenEditor }: HomeScreenProps) {
    * Editor tools + export flows matching the query — rendered as an extra
    * "In the editor" section below the standalone results. Empty until the
    * user types (the resting grid shows only the standalone cards; the
-   * editor's 18 tools are reached by dropping a PDF).
+   * editor's tools are reached by dropping a PDF).
    */
   const editorMatches = useMemo(() => {
     const q = searchQuery.trim().toLowerCase();
@@ -772,7 +784,7 @@ export function App() {
   if (view.kind === "editor") {
     return (
       <>
-        <Suspense fallback={<LoadingSpinner />}>
+        <Suspense fallback={<EditorLoadingFallback />}>
           <EditorView initialFile={view.file} initialTool={view.tool ?? null} onExit={goHome} />
         </Suspense>
         <ReloadPrompt />

--- a/src/editor/ExportModal.tsx
+++ b/src/editor/ExportModal.tsx
@@ -51,6 +51,7 @@ import {
 import { renderPagesToBlobs } from "../utils/pdf-renderer.ts";
 import { flattenDestructiveObjects, hasPendingDestructive } from "./doc.ts";
 import { useEditorActions, useEditorRead, useToolSlice } from "./EditorContext.tsx";
+import { Switch } from "./panels/controls.tsx";
 import { hasPendingPageChanges, ORGANIZE_ID } from "./panels/OrganizeTool.tsx";
 import { Segmented } from "./panels/WholeDocPanel.tsx";
 
@@ -135,36 +136,6 @@ function FormatCard({
         </span>
       </span>
       {selected && <Check className="h-4 w-4 shrink-0 text-primary-600 dark:text-primary-400" />}
-    </button>
-  );
-}
-
-/** Accessible on/off switch. */
-function Switch({
-  checked,
-  onChange,
-  label,
-}: {
-  checked: boolean;
-  onChange: (v: boolean) => void;
-  label: string;
-}) {
-  return (
-    <button
-      type="button"
-      role="switch"
-      aria-checked={checked}
-      aria-label={label}
-      onClick={() => onChange(!checked)}
-      className={`relative h-6 w-11 shrink-0 rounded-full transition-[color,background-color,transform] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ${
-        checked ? "bg-primary-600" : "bg-slate-300 dark:bg-dark-border"
-      }`}
-    >
-      <span
-        className={`absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
-          checked ? "translate-x-5" : "translate-x-0"
-        }`}
-      />
     </button>
   );
 }

--- a/src/editor/panels/AnnotateTool.tsx
+++ b/src/editor/panels/AnnotateTool.tsx
@@ -20,15 +20,19 @@
 import {
   ArrowUpRight,
   Bold,
+  Check,
   Circle,
+  CircleDot,
   Highlighter,
   Italic,
   Minus,
   MousePointer2,
   Pen,
   Square,
+  SquareCheck,
   Trash2,
   Type,
+  X,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ColorPicker, hexToRgb, rgbToHex } from "../../components/ColorPicker.tsx";
@@ -37,11 +41,13 @@ import type {
   Annotation,
   AnnotationColor,
   FontFamily,
+  IconId,
   TextFontId,
 } from "../../utils/pdf-operations.ts";
 import {
   annotatePdf,
   decomposeTextFont,
+  iconGeometry,
   resolveTextFont,
   TEXT_BG_HEIGHT_EM,
   TEXT_BG_PAD_EM,
@@ -54,12 +60,16 @@ import { useEditorActions, useEditorRead, useToolSlice } from "../EditorContext.
 import { PrimaryAction } from "./PrimaryAction.tsx";
 import { type StagePoint, useInlineEditor, useStageProps } from "../stage.tsx";
 import {
+  ACCENT,
+  type Box,
+  CORNER_IDS,
   drawSelectionChrome,
   type HandleId,
   HANDLE_CURSOR,
   HANDLE_IDS,
   hitHandle,
   resizeBBox,
+  resizeBBoxAspect,
 } from "../resize-handles.ts";
 import { Labeled, RangeField, Toggle } from "./controls.tsx";
 
@@ -68,11 +78,29 @@ const DEFAULT_HEX = "#1e293b";
 const DEFAULT_FILL_HEX = "#2563eb";
 const DEFAULT_BG_HEX = "#ffffff";
 const DEFAULT_TEXT_PT = 16;
-/** Selection chrome + drag affordances use the single Ocean-Blue accent. */
-const ACCENT = "#2563eb";
 
-type Mode = "select" | "pen" | "highlight" | "line" | "arrow" | "rect" | "ellipse" | "text";
+type Mode =
+  | "select"
+  | "pen"
+  | "highlight"
+  | "line"
+  | "arrow"
+  | "rect"
+  | "ellipse"
+  | "text"
+  | "icon";
 type TextAnnotation = Extract<Annotation, { kind: "text" }>;
+
+/** Default stamped-icon box, as a fraction of page WIDTH (kept square via the
+ *  page aspect at placement). ~5% ≈ a checkbox-sized tick on a Letter page. */
+const ICON_DEFAULT_W = 0.05;
+/** The form-glyph palette shown when the Icon tool is armed. */
+const ICON_CHOICES: { id: IconId; label: string; icon: typeof Check }[] = [
+  { id: "check", label: "Tick", icon: Check },
+  { id: "cross", label: "Cross", icon: X },
+  { id: "dot", label: "Filled dot", icon: CircleDot },
+  { id: "circle", label: "Circle", icon: Circle },
+];
 
 const PEN_THICK = 0.0035;
 const HIGHLIGHT_THICK = 0.022;
@@ -160,6 +188,7 @@ function annotationBBox(a: Annotation, w: number, h: number) {
     }
     case "rect":
     case "ellipse":
+    case "icon":
       return { x: a.x, y: a.y, w: a.w, h: a.h };
     case "line":
     case "arrow":
@@ -191,16 +220,30 @@ function annotationBBox(a: Annotation, w: number, h: number) {
  *  (stroke/line/arrow) are move-only. */
 function isResizable(a: Annotation): boolean {
   return (
-    a.kind === "rect" || a.kind === "ellipse" || (a.kind === "text" && a.w != null && a.h != null)
+    a.kind === "rect" ||
+    a.kind === "ellipse" ||
+    a.kind === "icon" ||
+    (a.kind === "text" && a.w != null && a.h != null)
   );
 }
 
-/** Write a new bbox back onto a resizable mark (rect/ellipse/box-text). */
+/** Write a new bbox back onto a resizable mark (rect/ellipse/icon/box-text). */
 function applyBBox(a: Annotation, b: { x: number; y: number; w: number; h: number }): Annotation {
-  if (a.kind === "rect" || a.kind === "ellipse" || a.kind === "text") {
+  if (a.kind === "rect" || a.kind === "ellipse" || a.kind === "text" || a.kind === "icon") {
     return { ...a, x: b.x, y: b.y, w: b.w, h: b.h };
   }
   return a;
+}
+
+/** Icons are aspect-true (a square glyph) → corner-only handles + aspect-locked
+ *  resize, exactly like a placed signature/QR stamp, so they never distort. Every
+ *  other resizable mark uses the full eight-handle free resize. */
+const handlesFor = (a: Annotation): HandleId[] => (a.kind === "icon" ? CORNER_IDS : HANDLE_IDS);
+function resizeAnnBBox(orig: Box, handle: HandleId, dx: number, dy: number, a: Annotation): Box {
+  if (a.kind === "icon") {
+    return resizeBBoxAspect(orig, handle, dx, dy, orig.h > 0 ? orig.w / orig.h : 1);
+  }
+  return resizeBBox(orig, handle, dx, dy);
 }
 
 /** Distance (px) from point (px,py) to segment (ax,ay)-(bx,by). */
@@ -250,6 +293,7 @@ function translateAnnotation(a: Annotation, dx: number, dy: number): Annotation 
       return { ...a, points: a.points.map((p) => ({ x: p.x + dx, y: p.y + dy })) };
     case "rect":
     case "ellipse":
+    case "icon":
       return { ...a, x: a.x + dx, y: a.y + dy };
     case "line":
     case "arrow":
@@ -316,6 +360,50 @@ function drawEllipsePath(
 ) {
   ctx.beginPath();
   ctx.ellipse(x + w / 2, y + h / 2, Math.abs(w / 2), Math.abs(h / 2), 0, 0, Math.PI * 2);
+}
+
+/** Paint a stamped form glyph into the largest centred square of its box, from
+ *  the shared unit-square geometry — the same description the pdf-lib burn uses,
+ *  so the preview matches the output. */
+function drawIconGlyph(
+  ctx: CanvasRenderingContext2D,
+  a: Extract<Annotation, { kind: "icon" }>,
+  w: number,
+  h: number,
+) {
+  const bx = a.x * w;
+  const by = a.y * h;
+  const bw = a.w * w;
+  const bh = a.h * h;
+  const s = Math.min(bw, bh);
+  const ox = bx + (bw - s) / 2;
+  const oy = by + (bh - s) / 2;
+  const ux = (u: number) => ox + u * s;
+  const uy = (v: number) => oy + v * s;
+  const g = iconGeometry(a.icon);
+  const col = fillStyle(a.color);
+  ctx.save();
+  ctx.strokeStyle = col;
+  ctx.fillStyle = col;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+  ctx.lineWidth = Math.max(1.5, g.weight * s);
+  for (const stroke of g.strokes) {
+    ctx.beginPath();
+    stroke.forEach((p, i) => (i ? ctx.lineTo(ux(p.x), uy(p.y)) : ctx.moveTo(ux(p.x), uy(p.y))));
+    ctx.stroke();
+  }
+  if (g.disc) {
+    ctx.beginPath();
+    ctx.arc(ux(g.disc.cx), uy(g.disc.cy), g.disc.r * s, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  if (g.ring) {
+    ctx.beginPath();
+    ctx.arc(ux(g.ring.cx), uy(g.ring.cy), g.ring.r * s, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.restore();
 }
 
 function drawAnnotation(ctx: CanvasRenderingContext2D, a: Annotation, w: number, h: number) {
@@ -428,6 +516,8 @@ function drawAnnotation(ctx: CanvasRenderingContext2D, a: Annotation, w: number,
       ctx.fillText(a.text, a.x * w, a.y * h + size);
     }
     ctx.restore();
+  } else if (a.kind === "icon") {
+    drawIconGlyph(ctx, a, w, h);
   }
 }
 
@@ -466,10 +556,12 @@ export function Stage() {
   const bgEnabled = (slice.bgEnabled as boolean) ?? false;
   const bgHex = (slice.bgHex as string) ?? DEFAULT_BG_HEX;
   const bgOpacity = (slice.bgOpacity as number) ?? 1;
+  const iconId = (slice.iconId as IconId) ?? "check";
 
   const color = useMemo(() => hexToRgb(colorHex), [colorHex]);
   const fillColor = useMemo(() => hexToRgb(fillHex), [fillHex]);
   const bgColor = useMemo(() => hexToRgb(bgHex), [bgHex]);
+  const pageWidthPt = doc?.pages[selectedPage]?.widthPt ?? 0;
   const pageHeightPt = doc?.pages[selectedPage]?.heightPt ?? 0;
 
   // Latch the live doc so stable handlers/effects read the freshest objects.
@@ -548,6 +640,7 @@ export function Stage() {
   const lineMode = mode === "line" || mode === "arrow";
   const textMode = mode === "text";
   const selectMode = mode === "select";
+  const iconMode = mode === "icon";
 
   const strokeOpacity = mode === "highlight" ? 0.4 : 1;
   const strokeThick = mode === "highlight" ? HIGHLIGHT_THICK : PEN_THICK;
@@ -897,7 +990,7 @@ export function Stage() {
               ? dragGeom.ann
               : (sel.payload as Annotation);
         drawSelectionChrome(ctx, annotationBBox(live, w, h), w, h, {
-          handles: isResizable(live) ? HANDLE_IDS : [],
+          handles: isResizable(live) ? handlesFor(live) : [],
           accent: ACCENT,
         });
       }
@@ -923,7 +1016,12 @@ export function Stage() {
   const onPointerDown = useCallback(
     (p: StagePoint) => {
       startRef.current = { x: p.xPct, y: p.yPct };
-      if (selectMode) {
+      // Select AND Icon mode share the interactive path: a handle starts a
+      // resize, a hit starts a drag. They differ only on a miss — Select just
+      // deselects; Icon stamps a new glyph on the tap-up (handled in onPointerUp),
+      // so an icon can be placed, then immediately moved or resized like a
+      // signature/QR stamp, all without leaving the tool.
+      if (selectMode || iconMode) {
         const { w, h } = paintWHRef.current;
         // A handle of the currently-selected resizable mark wins over hit-testing
         // other marks underneath — start a resize.
@@ -931,7 +1029,7 @@ export function Stage() {
         const selAnn = selObj?.payload as Annotation | undefined;
         if (selObj && selObj.pageIndex === selectedPage && selAnn && isResizable(selAnn)) {
           const bbox = annotationBBox(selAnn, w, h);
-          const handle = hitHandle(bbox, p.xPct * w, p.yPct * h, w, h);
+          const handle = hitHandle(bbox, p.xPct * w, p.yPct * h, w, h, handlesFor(selAnn));
           if (handle) {
             resizeStartRef.current = {
               id: selObj.id,
@@ -948,10 +1046,13 @@ export function Stage() {
         let hit: (typeof objs)[number] | null = null;
         for (let i = objs.length - 1; i >= 0; i--) {
           const o = objs[i];
+          // In Icon mode only existing icons are grabbable, so a tap on empty
+          // page (or over other marks) still stamps a new glyph.
           if (
             o.kind === "annotation" &&
             o.pageIndex === selectedPage &&
             o.payload &&
+            (selectMode || (o.payload as Annotation).kind === "icon") &&
             hitTest(o.payload as Annotation, p.xPct, p.yPct, w, h)
           ) {
             hit = o;
@@ -984,16 +1085,26 @@ export function Stage() {
         setDraftPoints([{ x: p.xPct, y: p.yPct }]);
       }
     },
-    [selectMode, boxMode, lineMode, textMode, doc, selectedPage, selectedId, patchToolState],
+    [
+      selectMode,
+      boxMode,
+      lineMode,
+      textMode,
+      iconMode,
+      doc,
+      selectedPage,
+      selectedId,
+      patchToolState,
+    ],
   );
 
   const onPointerMove = useCallback(
     (p: StagePoint) => {
-      if (selectMode) {
+      if (selectMode || iconMode) {
         const { w, h } = paintWHRef.current;
         const rs = resizeStartRef.current;
         if (rs) {
-          const nb = resizeBBox(rs.bbox, rs.handle, p.xPct - rs.sx, p.yPct - rs.sy);
+          const nb = resizeAnnBBox(rs.bbox, rs.handle, p.xPct - rs.sx, p.yPct - rs.sy, rs.orig);
           setResizeGeom({ id: rs.id, ann: applyBBox(rs.orig, nb) });
           return;
         }
@@ -1005,7 +1116,14 @@ export function Stage() {
           const selAnn = selObj?.payload as Annotation | undefined;
           const over =
             selObj && selObj.pageIndex === selectedPage && selAnn && isResizable(selAnn)
-              ? hitHandle(annotationBBox(selAnn, w, h), p.xPct * w, p.yPct * h, w, h)
+              ? hitHandle(
+                  annotationBBox(selAnn, w, h),
+                  p.xPct * w,
+                  p.yPct * h,
+                  w,
+                  h,
+                  handlesFor(selAnn),
+                )
               : null;
           setHoverHandle((prev) => (prev === over ? prev : over));
           return;
@@ -1043,26 +1161,53 @@ export function Stage() {
         }
       }
     },
-    [selectMode, boxMode, lineMode, textMode, doc, selectedId, selectedPage],
+    [selectMode, boxMode, lineMode, textMode, iconMode, doc, selectedId, selectedPage],
   );
 
   const onPointerUp = useCallback(
     (p: StagePoint, e: { timeStamp: number }) => {
       const s = startRef.current;
       startRef.current = null;
-      if (selectMode) {
+      if (selectMode || iconMode) {
         const rs = resizeStartRef.current;
         if (rs) {
           resizeStartRef.current = null;
           setResizeGeom(null);
-          const nb = resizeBBox(rs.bbox, rs.handle, p.xPct - rs.sx, p.yPct - rs.sy);
+          const nb = resizeAnnBBox(rs.bbox, rs.handle, p.xPct - rs.sx, p.yPct - rs.sy, rs.orig);
           moveObject(rs.id, { payload: applyBBox(rs.orig, nb) }, "Resize annotation");
           return;
         }
         const ds = dragStartRef.current;
         dragStartRef.current = null;
         setDragGeom(null);
-        if (!ds) return;
+        if (!ds) {
+          // Nothing was grabbed. In Icon mode that's a tap on empty page → stamp
+          // a new glyph (sized square via the page aspect), staying armed so a
+          // form's many ticks go down one tap each. It is NOT auto-selected: tap
+          // it again to select/move/resize it.
+          if (iconMode && s) {
+            const aspect = pageWidthPt > 0 && pageHeightPt > 0 ? pageWidthPt / pageHeightPt : 1;
+            const wPct = ICON_DEFAULT_W;
+            const hPct = wPct * aspect;
+            const x = Math.min(Math.max(0, p.xPct - wPct / 2), Math.max(0, 1 - wPct));
+            const y = Math.min(Math.max(0, p.yPct - hPct / 2), Math.max(0, 1 - hPct));
+            addObject({
+              kind: "annotation",
+              pageIndex: selectedPage,
+              payload: {
+                kind: "icon",
+                icon: iconId,
+                pageIndex: selectedPage,
+                x,
+                y,
+                w: wPct,
+                h: hPct,
+                color,
+              },
+            });
+          }
+          return;
+        }
         if (ds.moved) {
           // Recompute the final geometry from the start ref + this point (like
           // the draft-box commit) so it never depends on the live dragGeom state.
@@ -1175,6 +1320,8 @@ export function Stage() {
       boxMode,
       lineMode,
       textMode,
+      iconMode,
+      iconId,
       mode,
       color,
       fill,
@@ -1186,6 +1333,7 @@ export function Stage() {
       patchToolState,
       flushPenFrame,
       doc,
+      pageWidthPt,
       pageHeightPt,
       openNewText,
       openEditText,
@@ -1206,13 +1354,16 @@ export function Stage() {
   }, [flushPenFrame]);
 
   useStageProps({
-    cursor: textMode
-      ? "crosshair"
+    // Over a selected mark's resize handle → directional cursor (Select + Icon).
+    // Otherwise: Select rests at default; Icon shows "copy" (tap to drop a stamp,
+    // like signature/QR); the drawing tools show a crosshair.
+    cursor: hoverHandle
+      ? HANDLE_CURSOR[hoverHandle]
       : selectMode
-        ? hoverHandle
-          ? HANDLE_CURSOR[hoverHandle]
-          : "default"
-        : "crosshair",
+        ? "default"
+        : iconMode
+          ? "copy"
+          : "crosshair",
     paintOverlay,
     onPointerDown,
     onPointerMove,
@@ -1232,6 +1383,7 @@ const MODES: { id: Mode; label: string; icon: typeof Pen }[] = [
   { id: "rect", label: "Rectangle", icon: Square },
   { id: "ellipse", label: "Oval", icon: Circle },
   { id: "text", label: "Text", icon: Type },
+  { id: "icon", label: "Icons", icon: SquareCheck },
 ];
 
 /** A square Bold / Italic toggle, matching the selected-look used across pickers. */
@@ -1325,6 +1477,7 @@ export function Panel() {
   const bgEnabled = (slice.bgEnabled as boolean) ?? false;
   const bgHex = (slice.bgHex as string) ?? DEFAULT_BG_HEX;
   const bgOpacity = (slice.bgOpacity as number) ?? 1;
+  const iconId = (slice.iconId as IconId) ?? "check";
   const sizeHint = slice.sizeHint as string | undefined;
 
   const objects = doc?.objects ?? [];
@@ -1332,6 +1485,7 @@ export function Panel() {
   const selObj = selectedId ? objects.find((o) => o.id === selectedId) : undefined;
   const selAnn = selObj?.payload as Annotation | undefined;
   const isTextSel = selAnn?.kind === "text";
+  const isIconMode = mode === "icon";
   const selPageHeightPt = selObj ? (doc?.pages[selObj.pageIndex]?.heightPt ?? 0) : 0;
 
   // Coalesce live object edits into one undo step (a slider drag = one entry).
@@ -1573,6 +1727,42 @@ export function Panel() {
       ) : (
         showShapeColor && (
           <>
+            {isIconMode && (
+              <Labeled label="Icon">
+                <div className="grid grid-cols-4 gap-1.5">
+                  {ICON_CHOICES.map((c) => {
+                    const Ico = c.icon;
+                    // When an icon is selected, the palette reflects (and edits)
+                    // THAT glyph; otherwise it sets the next-placed glyph.
+                    const selIcon = selAnn?.kind === "icon" ? selAnn.icon : undefined;
+                    const on = (selIcon ?? iconId) === c.id;
+                    return (
+                      <button
+                        key={c.id}
+                        type="button"
+                        onClick={() => {
+                          patchToolState(TOOL_ID, { iconId: c.id });
+                          if (selObj && selAnn?.kind === "icon") {
+                            updateObject(selObj.id, { payload: { ...selAnn, icon: c.id } });
+                            scheduleCommit("Change icon");
+                          }
+                        }}
+                        aria-pressed={on}
+                        aria-label={c.label}
+                        title={c.label}
+                        className={`flex h-10 items-center justify-center rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
+                          on
+                            ? "border-primary-600 bg-primary-600 text-white"
+                            : "border-slate-200 dark:border-dark-border text-slate-600 dark:text-dark-text-muted hover:bg-slate-50 dark:hover:bg-dark-surface-alt"
+                        }`}
+                      >
+                        <Ico className="h-5 w-5" />
+                      </button>
+                    );
+                  })}
+                </div>
+              </Labeled>
+            )}
             <Labeled label={showFill ? "Stroke" : "Colour"}>
               <ColorPicker value={colorHex} onChange={onShapeColor} />
             </Labeled>
@@ -1617,7 +1807,9 @@ export function Panel() {
           ? "Tap a mark to select, drag to move (arrow keys nudge, Shift = bigger step), pull a handle to resize, Delete to remove. Double-click a text box to edit it."
           : mode === "text"
             ? "Drag a box on the page, then type inside it — text wraps to the box. Or tap for a default box. Drag or resize it any time."
-            : "Draw on the page; the mark is selected so you can drag or resize it. Page text stays selectable."}
+            : mode === "icon"
+              ? "Tap the page to stamp the chosen icon — great for ticking boxes or filling radios on a printed form. Tap an existing icon to select it, then drag to move or pull a corner to resize. Delete removes the selected one."
+              : "Draw on the page; the mark is selected so you can drag or resize it. Page text stays selectable."}
       </p>
     </div>
   );

--- a/src/editor/panels/AnnotateTool.tsx
+++ b/src/editor/panels/AnnotateTool.tsx
@@ -53,6 +53,14 @@ import { docToFile } from "../doc.ts";
 import { useEditorActions, useEditorRead, useToolSlice } from "../EditorContext.tsx";
 import { PrimaryAction } from "./PrimaryAction.tsx";
 import { type StagePoint, useInlineEditor, useStageProps } from "../stage.tsx";
+import {
+  drawSelectionChrome,
+  type HandleId,
+  HANDLE_CURSOR,
+  HANDLE_IDS,
+  hitHandle,
+  resizeBBox,
+} from "../resize-handles.ts";
 import { Labeled, RangeField, Toggle } from "./controls.tsx";
 
 const TOOL_ID = "annotate-pdf";
@@ -75,25 +83,6 @@ const DEFAULT_TEXT_W = 0.34;
 const DEFAULT_TEXT_H = 0.1;
 /** Smallest box a drag must cover to count as a custom region (else a tap). */
 const MIN_DRAG_FRAC = 0.02;
-/** Min box size (fractions) a resize can shrink a rect/oval/text box to. */
-const MIN_BOX_FRAC = 0.015;
-/** Hit slop (device px) around a resize handle. */
-const HANDLE_TOL_PX = 11;
-/** Painted half-size (device px) of a resize handle square. */
-const HANDLE_HALF_PX = 4;
-/** The eight resize handles, by compass id. */
-type HandleId = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
-const HANDLE_IDS: HandleId[] = ["nw", "n", "ne", "e", "se", "s", "sw", "w"];
-const HANDLE_CURSOR: Record<HandleId, string> = {
-  nw: "nwse-resize",
-  n: "ns-resize",
-  ne: "nesw-resize",
-  e: "ew-resize",
-  se: "nwse-resize",
-  s: "ns-resize",
-  sw: "nesw-resize",
-  w: "ew-resize",
-};
 /** Pointer travel (device px) before a select-mode press counts as a drag, not a
  *  click — keeps a tap-to-select from committing a zero-distance move. */
 const MOVE_THRESHOLD_PX = 4;
@@ -204,77 +193,6 @@ function isResizable(a: Annotation): boolean {
   return (
     a.kind === "rect" || a.kind === "ellipse" || (a.kind === "text" && a.w != null && a.h != null)
   );
-}
-
-/** Device-px centres of the eight handles around a fraction bbox (+chrome pad). */
-function handleCenters(
-  b: { x: number; y: number; w: number; h: number },
-  w: number,
-  h: number,
-): Record<HandleId, { x: number; y: number }> {
-  const pad = 3;
-  const x0 = b.x * w - pad;
-  const y0 = b.y * h - pad;
-  const x1 = (b.x + b.w) * w + pad;
-  const y1 = (b.y + b.h) * h + pad;
-  const mx = (x0 + x1) / 2;
-  const my = (y0 + y1) / 2;
-  return {
-    nw: { x: x0, y: y0 },
-    n: { x: mx, y: y0 },
-    ne: { x: x1, y: y0 },
-    e: { x: x1, y: my },
-    se: { x: x1, y: y1 },
-    s: { x: mx, y: y1 },
-    sw: { x: x0, y: y1 },
-    w: { x: x0, y: my },
-  };
-}
-
-/** Which handle (if any) the device-px point lands on for the given bbox. */
-function hitHandle(
-  b: { x: number; y: number; w: number; h: number },
-  px: number,
-  py: number,
-  w: number,
-  h: number,
-): HandleId | null {
-  const centers = handleCenters(b, w, h);
-  for (const id of HANDLE_IDS) {
-    const c = centers[id];
-    if (Math.abs(px - c.x) <= HANDLE_TOL_PX && Math.abs(py - c.y) <= HANDLE_TOL_PX) return id;
-  }
-  return null;
-}
-
-/** Resize a fraction bbox by dragging `handle` by a fraction delta, keeping the
- *  opposite edge(s) pinned and clamping to a minimum size within the page. */
-function resizeBBox(
-  orig: { x: number; y: number; w: number; h: number },
-  handle: HandleId,
-  dx: number,
-  dy: number,
-): { x: number; y: number; w: number; h: number } {
-  let { x, y, w, h } = orig;
-  const right = orig.x + orig.w;
-  const bottom = orig.y + orig.h;
-  if (handle.includes("w")) {
-    x = Math.min(orig.x + dx, right - MIN_BOX_FRAC);
-    x = Math.max(0, x);
-    w = right - x;
-  }
-  if (handle.includes("e")) {
-    w = Math.max(MIN_BOX_FRAC, Math.min(orig.w + dx, 1 - orig.x));
-  }
-  if (handle.includes("n")) {
-    y = Math.min(orig.y + dy, bottom - MIN_BOX_FRAC);
-    y = Math.max(0, y);
-    h = bottom - y;
-  }
-  if (handle.includes("s")) {
-    h = Math.max(MIN_BOX_FRAC, Math.min(orig.h + dy, 1 - orig.y));
-  }
-  return { x, y, w, h };
 }
 
 /** Write a new bbox back onto a resizable mark (rect/ellipse/box-text). */
@@ -511,62 +429,6 @@ function drawAnnotation(ctx: CanvasRenderingContext2D, a: Annotation, w: number,
     }
     ctx.restore();
   }
-}
-
-/** Dashed selection box around a mark's bbox, with square resize handles when
- *  the mark is resizable (rect / oval / box-text) — corners only for thin marks. */
-function drawSelectionChrome(
-  ctx: CanvasRenderingContext2D,
-  b: { x: number; y: number; w: number; h: number },
-  w: number,
-  h: number,
-  resizable: boolean,
-) {
-  const pad = 3;
-  const x = b.x * w - pad;
-  const y = b.y * h - pad;
-  const bw = b.w * w + pad * 2;
-  const bh = b.h * h + pad * 2;
-  ctx.save();
-  ctx.strokeStyle = ACCENT;
-  ctx.lineWidth = 1.5;
-  ctx.setLineDash([4, 3]);
-  ctx.strokeRect(x, y, bw, bh);
-  ctx.setLineDash([]);
-  if (resizable) {
-    // Eight grab handles (white fill + accent border so they read on any page).
-    const centers = handleCenters(b, w, h);
-    ctx.lineWidth = 1.5;
-    for (const id of HANDLE_IDS) {
-      const c = centers[id];
-      ctx.fillStyle = "#ffffff";
-      ctx.fillRect(
-        c.x - HANDLE_HALF_PX,
-        c.y - HANDLE_HALF_PX,
-        HANDLE_HALF_PX * 2,
-        HANDLE_HALF_PX * 2,
-      );
-      ctx.strokeStyle = ACCENT;
-      ctx.strokeRect(
-        c.x - HANDLE_HALF_PX,
-        c.y - HANDLE_HALF_PX,
-        HANDLE_HALF_PX * 2,
-        HANDLE_HALF_PX * 2,
-      );
-    }
-  } else {
-    ctx.fillStyle = ACCENT;
-    const hs = 3;
-    for (const [hx, hy] of [
-      [x, y],
-      [x + bw, y],
-      [x, y + bh],
-      [x + bw, y + bh],
-    ]) {
-      ctx.fillRect(hx - hs, hy - hs, hs * 2, hs * 2);
-    }
-  }
-  ctx.restore();
 }
 
 /** What the inline editor is anchored to. Style is read live from the slice so
@@ -1034,7 +896,10 @@ export function Stage() {
             : dragGeom && dragGeom.id === sel.id
               ? dragGeom.ann
               : (sel.payload as Annotation);
-        drawSelectionChrome(ctx, annotationBBox(live, w, h), w, h, isResizable(live));
+        drawSelectionChrome(ctx, annotationBBox(live, w, h), w, h, {
+          handles: isResizable(live) ? HANDLE_IDS : [],
+          accent: ACCENT,
+        });
       }
     },
     [

--- a/src/editor/panels/AutoFillTool.tsx
+++ b/src/editor/panels/AutoFillTool.tsx
@@ -242,7 +242,10 @@ export function Panel() {
                 )}
               </div>
 
-              <div className="thin-scrollbar flex max-h-72 flex-col gap-2 overflow-y-auto pr-1">
+              {/* px-1 py-1: room for each input's focus ring inside the scroll
+                  box — overflow-y-auto also clips overflow-x, so a flush-left
+                  input had its focus ring cropped on the left edge. */}
+              <div className="thin-scrollbar flex max-h-72 flex-col gap-2 overflow-y-auto px-1 py-1">
                 {fields.map((f, i) => (
                   <Labeled key={`${f.pageIndex}-${i}`} label={f.label || "Field"} normalCase>
                     <div className="flex items-center gap-1.5">

--- a/src/editor/panels/CodeStampTool.tsx
+++ b/src/editor/panels/CodeStampTool.tsx
@@ -1,149 +1,514 @@
-// CodeStampTool.tsx — Stamp a scannable QR code or Code 128 barcode onto the
-// document from a URL, case number, or hash. An options-only Panel (no canvas
-// interaction) so it reads identically in the desktop right panel and the mobile
-// bottom sheet. A live preview renders the actual code as you type, and the page
-// scope lets you place it on every page, the cover only, or just the current
-// page. Apply burns it in as crisp vector graphics via addCodeStamp.
+// CodeStampTool.tsx — Canvas-placement tool for a scannable QR code or Code 128
+// barcode (from a URL, case number, or hash). The Panel captures the symbology,
+// payload, colour, and (barcodes) a caption into the tool slice and shows a live
+// preview; the Stage lets the user TAP the page to drop the code, DRAG it to
+// reposition, and DRAG A CORNER to resize it (aspect-locked, so QR stays square
+// and a barcode keeps its proportions). Placed codes are `stamp` overlay objects
+// carrying the rendered preview image + payload.
+//
+// On Apply, `addCodeStampAt` burns each placed code as sharp vector art (not the
+// raster preview) sized to its box; the stamp objects are then dropped. An
+// "Apply to all pages" shortcut replicates the placement across the document for
+// the every-page workflow the old corner-anchored tool covered. See CLAUDE.md
+// (canvas placement, sibling of the signature tool).
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Layers } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import qrcode from "qrcode-generator";
+import { addCodeStampAt, type CodeStampType, encodeCode128B } from "../../utils/pdf-operations.ts";
+import { ColorPicker, hexToRgb } from "../../components/ColorPicker.tsx";
+import { useEditorActions, useEditorRead, useToolSlice } from "../EditorContext.tsx";
+import { PrimaryAction } from "./PrimaryAction.tsx";
+import { useStageProps } from "../stage.tsx";
+import type { FractionRect } from "../types.ts";
 import {
-  addCodeStamp,
-  type CodeStampOptions,
-  type CodeStampType,
-  encodeCode128B,
-} from "../../utils/pdf-operations.ts";
-import type { PageNumberPosition } from "../../types.ts";
-import { docToFile } from "../doc.ts";
-import { useEditorActions, useEditorRead } from "../EditorContext.tsx";
-import { ColorRow, Labeled, PositionGrid, RangeField, TextField, Toggle } from "./controls.tsx";
-import { Segmented, WholeDocPanel } from "./WholeDocPanel.tsx";
+  type Box,
+  CORNER_IDS,
+  drawSelectionChrome,
+  type HandleId,
+  HANDLE_CURSOR,
+  hitHandle,
+  resizeBBoxAspect,
+} from "../resize-handles.ts";
+import { Labeled, TextField, Toggle } from "./controls.tsx";
+import { Segmented } from "./WholeDocPanel.tsx";
 
-const BLACK = { r: 17, g: 24, b: 39 };
+const TOOL_ID = "qr-stamp";
+const DEFAULT_COLOR = "#111827";
+const ACCENT = "#2563eb";
+const MOVE_THRESHOLD_PX = 4;
+/** Default placement width as a fraction of page width (QR is square-ish; a
+ *  barcode is wide, so it starts wider). */
+const DEFAULT_QR_W = 0.18;
+const DEFAULT_BAR_W = 0.42;
 
-type PageScope = "every" | "first" | "this";
+interface StampPayload {
+  type: CodeStampType;
+  content: string;
+  colorHex: string;
+  caption: boolean;
+  /** Rendered preview PNG for the on-canvas overlay (burn re-draws as vector). */
+  dataUrl: string;
+}
 
-/** QR preview as a data-URL (sync + cheap); null if encoding fails. */
-function useQrPreview(content: string): string | null {
-  return useMemo(() => {
-    const text = content.trim();
-    if (!text) return null;
+interface RenderedCode {
+  dataUrl: string;
+  /** Natural width / height of the rendered image. */
+  aspect: number;
+}
+
+const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+const rectToBox = (r: FractionRect): Box => ({ x: r.xPct, y: r.yPct, w: r.wPct, h: r.hPct });
+const boxToRect = (b: Box): FractionRect => ({ xPct: b.x, yPct: b.y, wPct: b.w, hPct: b.h });
+
+/** Barcode caption block as a fraction of bar height — matches addCodeStampAt. */
+const BARCODE_CAPTION_RATIO = 0.16 * 1.5;
+
+/** Render a QR / barcode to a coloured PNG data-URL (white backing, foreground
+ *  in `colorHex`) plus its aspect ratio. Proportions mirror the vector burn so
+ *  the placed preview matches the applied output. Returns null on invalid input. */
+function renderCode(
+  type: CodeStampType,
+  content: string,
+  colorHex: string,
+  caption: boolean,
+): RenderedCode | null {
+  const text = content.trim();
+  if (!text) return null;
+  if (type === "qr") {
     try {
       const qr = qrcode(0, "M");
       qr.addData(text);
       qr.make();
-      return qr.createDataURL(4, 2);
+      const n = qr.getModuleCount();
+      const quiet = 4;
+      const cell = 6;
+      const dim = (n + quiet * 2) * cell;
+      const c = document.createElement("canvas");
+      c.width = dim;
+      c.height = dim;
+      const ctx = c.getContext("2d");
+      if (!ctx) return null;
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, dim, dim);
+      ctx.fillStyle = colorHex;
+      for (let row = 0; row < n; row++) {
+        for (let col = 0; col < n; col++) {
+          if (qr.isDark(row, col))
+            ctx.fillRect((quiet + col) * cell, (quiet + row) * cell, cell, cell);
+        }
+      }
+      return { dataUrl: c.toDataURL("image/png"), aspect: 1 };
     } catch {
       return null;
     }
-  }, [content]);
+  }
+  try {
+    const pattern = encodeCode128B(text);
+    let totalModules = 20; // 10-module quiet zones each side
+    for (const ch of pattern) totalModules += Number(ch);
+    const moduleW = 2;
+    const barH = 64;
+    const capFS = caption ? barH * 0.16 : 0;
+    const captionBlock = caption ? barH * BARCODE_CAPTION_RATIO : 0;
+    const W = totalModules * moduleW;
+    const H = barH + captionBlock;
+    const c = document.createElement("canvas");
+    c.width = Math.ceil(W);
+    c.height = Math.ceil(H);
+    const ctx = c.getContext("2d");
+    if (!ctx) return null;
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, c.width, c.height);
+    ctx.fillStyle = colorHex;
+    let cursor = 10 * moduleW;
+    let isBar = true;
+    for (const ch of pattern) {
+      const runW = Number(ch) * moduleW;
+      if (isBar) ctx.fillRect(cursor, 0, runW, barH);
+      cursor += runW;
+      isBar = !isBar;
+    }
+    if (caption && capFS > 0) {
+      ctx.fillStyle = colorHex;
+      ctx.font = `${capFS}px Helvetica, Arial, sans-serif`;
+      ctx.textAlign = "center";
+      ctx.textBaseline = "alphabetic";
+      ctx.fillText(text, W / 2, barH + capFS);
+    }
+    return { dataUrl: c.toDataURL("image/png"), aspect: W / H };
+  } catch {
+    return null;
+  }
 }
 
-/** Draw the Code 128 barcode preview into a canvas — mirrors addCodeStamp's bar
- *  layout (10-module quiet zones, alternating bar/space starting with a bar). */
-function BarcodePreview({ content, valid }: { content: string; valid: boolean }) {
-  const ref = useRef<HTMLCanvasElement>(null);
-  useEffect(() => {
-    const canvas = ref.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    const W = canvas.width;
-    const H = canvas.height;
-    ctx.clearRect(0, 0, W, H);
-    ctx.fillStyle = "#ffffff";
-    ctx.fillRect(0, 0, W, H);
-    if (!valid) return;
-    try {
-      const pattern = encodeCode128B(content.trim());
-      let totalModules = 20; // quiet zones
-      for (const ch of pattern) totalModules += Number(ch);
-      const moduleW = W / totalModules;
-      ctx.fillStyle = "#111827";
-      let cursor = 10 * moduleW;
-      let isBar = true;
-      for (const ch of pattern) {
-        const runW = Number(ch) * moduleW;
-        // Snap both edges to integer pixels so sub-pixel bars (long payloads on
-        // the fixed-width canvas) don't overlap and eat the quiet zone — ceiling
-        // each width independently drifted the layout rightward.
-        if (isBar) {
-          const x0 = Math.round(cursor);
-          ctx.fillRect(x0, 0, Math.max(1, Math.round(cursor + runW) - x0), H);
-        }
-        cursor += runW;
-        isBar = !isBar;
-      }
-    } catch {
-      /* invalid content — leave blank */
-    }
-  }, [content, valid]);
-  return (
-    <canvas
-      ref={ref}
-      width={240}
-      height={72}
-      className="h-16 w-full"
-      aria-label="Barcode preview"
-    />
+export function Stage() {
+  const { doc, selectedPage } = useEditorRead();
+  const { addObject, moveObject, removeObject, patchToolState } = useEditorActions();
+  const slice = useToolSlice(TOOL_ID);
+  const type = (slice.type as CodeStampType) ?? "qr";
+  const content = (slice.content as string) ?? "";
+  const colorHex = (slice.colorHex as string) ?? DEFAULT_COLOR;
+  const caption = (slice.caption as boolean) ?? true;
+  const selectedId = slice.selectedId as string | undefined;
+
+  const docRef = useRef(doc);
+  docRef.current = doc;
+
+  // The staged code (current panel settings) → preview image + aspect, used when
+  // a tap places a new code. Memoised so it only re-renders on a settings change.
+  const staged = useMemo(
+    () => renderCode(type, content, colorHex, caption),
+    [type, content, colorHex, caption],
   );
+
+  // Lazy <img> cache for painting placed codes onto the overlay canvas.
+  const imgCache = useRef<Map<string, HTMLImageElement>>(new Map());
+  const [imgVersion, setImgVersion] = useState(0);
+  const getImg = useCallback((url: string): HTMLImageElement | null => {
+    if (!url) return null;
+    const cache = imgCache.current;
+    let img = cache.get(url);
+    if (!img) {
+      img = new Image();
+      img.onload = () => setImgVersion((v) => v + 1);
+      img.src = url;
+      cache.set(url, img);
+    }
+    return img.complete && img.naturalWidth ? img : null;
+  }, []);
+  useEffect(() => () => imgCache.current.clear(), []);
+  // Pre-decode placed codes on (re)mount so returning to the tool always
+  // repaints the preview (the cache is cleared on unmount).
+  useEffect(() => {
+    for (const o of docRef.current?.objects ?? []) {
+      if (o.kind !== "stamp") continue;
+      const url = (o.payload as StampPayload | undefined)?.dataUrl;
+      if (url) getImg(url);
+    }
+  }, [getImg]);
+  useEffect(() => {
+    const live = new Set<string>();
+    for (const o of doc?.objects ?? []) {
+      if (o.kind !== "stamp") continue;
+      const url = (o.payload as StampPayload | undefined)?.dataUrl;
+      if (url) live.add(url);
+    }
+    if (staged) live.add(staged.dataUrl);
+    for (const key of imgCache.current.keys()) {
+      if (!live.has(key)) imgCache.current.delete(key);
+    }
+  }, [doc, staged]);
+
+  const dragRef = useRef<{ id: string; dx: number; dy: number; moved: boolean } | null>(null);
+  const resizeRef = useRef<{
+    id: string;
+    handle: HandleId;
+    sx: number;
+    sy: number;
+    orig: FractionRect;
+    aspect: number;
+  } | null>(null);
+  const [liveGeom, setLiveGeom] = useState<{ id: string; rect: FractionRect } | null>(null);
+  const [hoverHandle, setHoverHandle] = useState<HandleId | null>(null);
+  const paintWHRef = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
+
+  useEffect(() => {
+    dragRef.current = null;
+    resizeRef.current = null;
+    setLiveGeom(null);
+    setHoverHandle(null);
+    patchToolState(TOOL_ID, { selectedId: undefined });
+  }, [selectedPage, patchToolState]);
+
+  const stampsOnPage = useCallback(
+    (pageIndex: number) =>
+      (docRef.current?.objects ?? []).filter(
+        (o) => o.kind === "stamp" && o.pageIndex === pageIndex && o.rect,
+      ),
+    [],
+  );
+
+  const rectOf = useCallback(
+    (id: string, rect: FractionRect): FractionRect =>
+      liveGeom && liveGeom.id === id ? liveGeom.rect : rect,
+    [liveGeom],
+  );
+
+  const paintOverlay = useCallback(
+    (ctx: CanvasRenderingContext2D, w: number, h: number, pageIndex: number) => {
+      paintWHRef.current = { w, h };
+      for (const o of doc?.objects ?? []) {
+        if (o.kind !== "stamp" || o.pageIndex !== pageIndex || !o.rect) continue;
+        const r = rectOf(o.id, o.rect);
+        const x = r.xPct * w;
+        const y = r.yPct * h;
+        const bw = r.wPct * w;
+        const bh = r.hPct * h;
+        const img = getImg((o.payload as StampPayload | undefined)?.dataUrl ?? "");
+        if (img) ctx.drawImage(img, x, y, bw, bh);
+        if (o.id === selectedId) {
+          drawSelectionChrome(ctx, rectToBox(r), w, h, { handles: CORNER_IDS, accent: ACCENT });
+        } else {
+          ctx.save();
+          ctx.strokeStyle = "rgba(100, 116, 139, 0.7)";
+          ctx.setLineDash([5, 4]);
+          ctx.lineWidth = 1.25;
+          ctx.strokeRect(x, y, bw, bh);
+          ctx.restore();
+        }
+      }
+    },
+    [doc, getImg, imgVersion, selectedId, rectOf],
+  );
+
+  const hitTest = useCallback(
+    (xPct: number, yPct: number) => {
+      const stamps = stampsOnPage(selectedPage);
+      for (let i = stamps.length - 1; i >= 0; i--) {
+        const r = rectOf(stamps[i].id, stamps[i].rect!);
+        if (xPct >= r.xPct && xPct <= r.xPct + r.wPct && yPct >= r.yPct && yPct <= r.yPct + r.hPct)
+          return stamps[i];
+      }
+      return null;
+    },
+    [stampsOnPage, selectedPage, rectOf],
+  );
+
+  useStageProps({
+    cursor: hoverHandle ? HANDLE_CURSOR[hoverHandle] : staged ? "copy" : "default",
+    paintOverlay,
+    onPointerDown: (p) => {
+      const { w, h } = paintWHRef.current;
+      const sel = stampsOnPage(selectedPage).find((o) => o.id === selectedId);
+      if (sel?.rect) {
+        const r = rectOf(sel.id, sel.rect);
+        const handle = hitHandle(rectToBox(r), p.xPct * w, p.yPct * h, w, h, CORNER_IDS);
+        if (handle) {
+          resizeRef.current = {
+            id: sel.id,
+            handle,
+            sx: p.xPct,
+            sy: p.yPct,
+            orig: r,
+            aspect: r.hPct > 0 ? r.wPct / r.hPct : 1,
+          };
+          return;
+        }
+      }
+      const hit = hitTest(p.xPct, p.yPct);
+      if (hit?.rect) {
+        const r = rectOf(hit.id, hit.rect);
+        dragRef.current = { id: hit.id, dx: p.xPct - r.xPct, dy: p.yPct - r.yPct, moved: false };
+        if (selectedId !== hit.id) patchToolState(TOOL_ID, { selectedId: hit.id });
+        return;
+      }
+      if (!staged) {
+        if (selectedId) patchToolState(TOOL_ID, { selectedId: undefined });
+        return;
+      }
+      const page = doc?.pages[selectedPage];
+      const wPct = type === "qr" ? DEFAULT_QR_W : DEFAULT_BAR_W;
+      const hPct =
+        page && page.heightPt > 0
+          ? (wPct * (page.widthPt / page.heightPt)) / staged.aspect
+          : wPct / staged.aspect;
+      const rect: FractionRect = {
+        xPct: clamp01(p.xPct - wPct / 2),
+        yPct: clamp01(p.yPct - hPct / 2),
+        wPct,
+        hPct,
+      };
+      const payload: StampPayload = { type, content, colorHex, caption, dataUrl: staged.dataUrl };
+      const id = addObject({ kind: "stamp", pageIndex: selectedPage, rect, payload });
+      if (id) patchToolState(TOOL_ID, { selectedId: id });
+    },
+    onPointerMove: (p) => {
+      const { w, h } = paintWHRef.current;
+      const rs = resizeRef.current;
+      if (rs) {
+        const nb = resizeBBoxAspect(
+          rectToBox(rs.orig),
+          rs.handle,
+          p.xPct - rs.sx,
+          p.yPct - rs.sy,
+          rs.aspect,
+        );
+        setLiveGeom({ id: rs.id, rect: boxToRect(nb) });
+        return;
+      }
+      const d = dragRef.current;
+      if (d) {
+        const obj = stampsOnPage(selectedPage).find((o) => o.id === d.id);
+        if (!obj?.rect) return;
+        const targetX = p.xPct - d.dx;
+        const targetY = p.yPct - d.dy;
+        if (!d.moved) {
+          const dxPx = (targetX - obj.rect.xPct) * w;
+          const dyPx = (targetY - obj.rect.yPct) * h;
+          if (Math.hypot(dxPx, dyPx) < MOVE_THRESHOLD_PX) return;
+          d.moved = true;
+        }
+        const { wPct, hPct } = obj.rect;
+        setLiveGeom({
+          id: d.id,
+          rect: {
+            xPct: clamp01(Math.min(targetX, 1 - wPct)),
+            yPct: clamp01(Math.min(targetY, 1 - hPct)),
+            wPct,
+            hPct,
+          },
+        });
+        return;
+      }
+      const sel = stampsOnPage(selectedPage).find((o) => o.id === selectedId);
+      const over = sel?.rect
+        ? hitHandle(rectToBox(rectOf(sel.id, sel.rect)), p.xPct * w, p.yPct * h, w, h, CORNER_IDS)
+        : null;
+      setHoverHandle((prev) => (prev === over ? prev : over));
+    },
+    onPointerUp: () => {
+      const rs = resizeRef.current;
+      resizeRef.current = null;
+      const d = dragRef.current;
+      dragRef.current = null;
+      const l = liveGeom;
+      setLiveGeom(null);
+      if (rs && l && l.id === rs.id) {
+        moveObject(rs.id, { rect: l.rect }, "Resize code");
+        return;
+      }
+      if (d?.moved && l && l.id === d.id) {
+        moveObject(d.id, { rect: l.rect }, "Move code");
+      }
+    },
+    onPointerCancel: () => {
+      dragRef.current = null;
+      resizeRef.current = null;
+      setLiveGeom(null);
+    },
+  });
+
+  useEffect(() => {
+    if (!selectedId) return;
+    const onKey = (e: KeyboardEvent) => {
+      const el = document.activeElement as HTMLElement | null;
+      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable))
+        return;
+      if (e.key !== "Delete" && e.key !== "Backspace") return;
+      const obj = docRef.current?.objects.find((o) => o.id === selectedId);
+      if (!obj || obj.pageIndex !== selectedPage) return;
+      e.preventDefault();
+      removeObject(selectedId);
+      patchToolState(TOOL_ID, { selectedId: undefined });
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedId, selectedPage, removeObject, patchToolState]);
+
+  return null;
 }
 
 export function Panel() {
-  const { applyTransform } = useEditorActions();
-  const { selectedPage } = useEditorRead();
-  const [type, setType] = useState<CodeStampType>("qr");
-  const [content, setContent] = useState("");
-  const [position, setPosition] = useState<PageNumberPosition>("bottom-right");
-  const [size, setSize] = useState(96);
-  const [color, setColor] = useState(BLACK);
-  const [caption, setCaption] = useState(true);
-  const [scope, setScope] = useState<PageScope>("every");
+  const { doc } = useEditorRead();
+  const { patchToolState, applyTransform, addObjects } = useEditorActions();
+  const slice = useToolSlice(TOOL_ID);
+  const type = (slice.type as CodeStampType) ?? "qr";
+  const content = (slice.content as string) ?? "";
+  const colorHex = (slice.colorHex as string) ?? DEFAULT_COLOR;
+  const caption = (slice.caption as boolean) ?? true;
 
   const trimmed = content.trim();
-  // Code 128-B only encodes printable ASCII; flag anything outside so Apply is
-  // blocked with a clear reason rather than throwing at burn time.
-  const barcodeValid = useMemo(() => {
-    if (!trimmed) return false;
-    return /^[\x20-\x7e]+$/.test(trimmed);
-  }, [trimmed]);
+  // Code 128-B only encodes printable ASCII; flag anything outside so a barcode
+  // can't be placed with un-encodable content.
+  const barcodeValid = useMemo(() => /^[\x20-\x7e]+$/.test(trimmed), [trimmed]);
+  const preview = useMemo(
+    () => renderCode(type, content, colorHex, caption),
+    [type, content, colorHex, caption],
+  );
+  const canPlace = type === "qr" ? !!preview : barcodeValid && !!preview;
 
-  const qrPreview = useQrPreview(content);
-  const canApply = type === "qr" ? !!qrPreview : barcodeValid;
+  const count = (doc?.objects ?? []).filter((o) => o.kind === "stamp").length;
+  const pageCount = doc?.pageCount ?? 0;
 
-  const pageIndices = scope === "every" ? undefined : scope === "first" ? [0] : [selectedPage];
+  // Replicate the placed code(s) from the first stamped page onto every other
+  // page (same fractional box) — the every-page workflow the old tool had.
+  const applyToAllPages = useCallback(() => {
+    const d = doc;
+    if (!d) return;
+    const stamps = d.objects.filter((o) => o.kind === "stamp" && o.rect && o.payload);
+    if (stamps.length === 0) return;
+    const firstPage = Math.min(...stamps.map((o) => o.pageIndex));
+    const template = stamps.filter((o) => o.pageIndex === firstPage);
+    const occupied = new Set(stamps.map((o) => o.pageIndex));
+    const additions = [];
+    for (let p = 0; p < d.pageCount; p++) {
+      if (occupied.has(p)) continue;
+      for (const t of template) {
+        additions.push({
+          kind: "stamp" as const,
+          pageIndex: p,
+          rect: { ...t.rect! },
+          payload: { ...(t.payload as StampPayload) },
+        });
+      }
+    }
+    if (additions.length > 0) addObjects(additions, "Code on all pages");
+  }, [doc, addObjects]);
 
-  const apply = () => {
-    const options: CodeStampOptions = {
-      type,
-      content: trimmed,
-      position,
-      size,
-      margin: 24,
-      color,
-      caption,
-    };
-    void applyTransform(async (d) => ({
-      bytes: await addCodeStamp(docToFile(d), options, pageIndices),
-      label: type === "qr" ? "QR code" : "Barcode",
-    }));
-  };
+  const apply = useCallback(() => {
+    void applyTransform(async (d) => {
+      const stamps = d.objects.filter((o) => o.kind === "stamp" && o.rect && o.payload);
+      // Group placements by payload identity (type/content/colour/caption) so one
+      // addCodeStampAt call burns every box that shares the same code.
+      const groups = new Map<
+        string,
+        {
+          payload: StampPayload;
+          placements: { pageIndex: number; x: number; y: number; width: number; height: number }[];
+        }
+      >();
+      for (const o of stamps) {
+        const payload = o.payload as StampPayload;
+        const r = o.rect!;
+        const page = d.pages[o.pageIndex];
+        if (!page) continue;
+        const key = `${payload.type}|${payload.content}|${payload.colorHex}|${payload.caption}`;
+        const width = r.wPct * page.widthPt;
+        const height = r.hPct * page.heightPt;
+        const x = r.xPct * page.widthPt;
+        const y = (1 - r.yPct) * page.heightPt - height;
+        const g = groups.get(key) ?? { payload, placements: [] };
+        g.placements.push({ pageIndex: o.pageIndex, x, y, width, height });
+        groups.set(key, g);
+      }
+      let bytes = d.bytes;
+      for (const { payload, placements } of groups.values()) {
+        const file = new File([bytes.slice(0)], d.fileName, { type: "application/pdf" });
+        bytes = await addCodeStampAt(
+          file,
+          {
+            type: payload.type,
+            content: payload.content,
+            color: hexToRgb(payload.colorHex),
+            caption: payload.caption,
+          },
+          placements,
+        );
+      }
+      return {
+        bytes,
+        label: stamps.length === 1 ? "Code stamp" : `Code stamp ×${stamps.length}`,
+        objects: d.objects.filter((o) => o.kind !== "stamp"),
+      };
+    });
+  }, [applyTransform]);
 
   return (
-    <WholeDocPanel
-      blurb="Stamp a scannable QR code or barcode — a verification URL, case number, or hash."
-      applyLabel={type === "qr" ? "Add QR code" : "Add barcode"}
-      disabled={!canApply}
-      onApply={apply}
-      note={
-        type === "barcode" && trimmed && !barcodeValid
-          ? "Barcodes support printable ASCII only — remove emoji or accented characters."
-          : undefined
-      }
-    >
+    <div className="flex flex-col gap-4">
       <Segmented<CodeStampType>
         value={type}
-        onChange={setType}
+        onChange={(v) => patchToolState(TOOL_ID, { type: v })}
         options={[
           { value: "qr", label: "QR code" },
           { value: "barcode", label: "Barcode" },
@@ -153,55 +518,72 @@ export function Panel() {
       <TextField
         label="Content"
         value={content}
-        onChange={setContent}
+        onChange={(v) => patchToolState(TOOL_ID, { content: v })}
         placeholder={type === "qr" ? "https://example.com" : "ABC-0001"}
       />
 
-      {/* Live preview — the actual encoded code, centred on a white card. */}
       <Labeled label="Preview">
         <div className="flex items-center justify-center rounded-lg border border-slate-200 dark:border-dark-border bg-white p-3">
-          {type === "qr" ? (
-            qrPreview ? (
-              <img src={qrPreview} alt="QR code preview" className="h-28 w-28" />
-            ) : (
-              <span className="py-8 text-xs text-slate-400">Enter content to preview</span>
-            )
-          ) : barcodeValid ? (
-            <BarcodePreview content={content} valid={barcodeValid} />
+          {preview ? (
+            <img
+              src={preview.dataUrl}
+              alt="Code preview"
+              className={type === "qr" ? "h-28 w-28" : "h-16 w-full object-contain"}
+            />
           ) : (
             <span className="py-8 text-xs text-slate-400">Enter content to preview</span>
           )}
         </div>
       </Labeled>
 
-      <PositionGrid value={position} onChange={setPosition} />
-
-      <Labeled label="Pages">
-        <Segmented<PageScope>
-          value={scope}
-          onChange={setScope}
-          options={[
-            { value: "every", label: "Every" },
-            { value: "first", label: "First" },
-            { value: "this", label: "This page" },
-          ]}
+      <Labeled label="Colour">
+        <ColorPicker
+          value={colorHex}
+          onChange={(hex) => patchToolState(TOOL_ID, { colorHex: hex })}
         />
       </Labeled>
 
-      <RangeField
-        label={type === "qr" ? "Size" : "Height"}
-        value={size}
-        min={48}
-        max={200}
-        suffix="pt"
-        onChange={setSize}
-      />
-
-      <ColorRow value={color} onChange={setColor} />
-
       {type === "barcode" && (
-        <Toggle label="Show text under barcode" checked={caption} onChange={setCaption} />
+        <Toggle
+          label="Show text under barcode"
+          checked={caption}
+          onChange={(v) => patchToolState(TOOL_ID, { caption: v })}
+        />
       )}
-    </WholeDocPanel>
+
+      <p className="rounded-lg bg-slate-50 dark:bg-dark-bg px-3 py-2 text-xs text-slate-500 dark:text-dark-text-muted">
+        {type === "barcode" && trimmed && !barcodeValid
+          ? "Barcodes support printable ASCII only — remove emoji or accented characters."
+          : canPlace
+            ? "Tap the page to place the code, drag to reposition, then pull a corner to resize."
+            : "Enter content to place a code."}
+      </p>
+
+      <span className="text-sm text-slate-600 dark:text-dark-text-muted">
+        {count} code{count === 1 ? "" : "s"} placed
+      </span>
+
+      {count > 0 && pageCount > 1 && (
+        <div className="flex flex-col gap-1.5">
+          <button
+            type="button"
+            onClick={applyToAllPages}
+            className="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 dark:border-dark-border px-3 py-2 text-sm font-medium text-slate-700 dark:text-dark-text hover:bg-slate-50 dark:hover:bg-dark-surface-alt transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+          >
+            <Layers className="h-4 w-4" />
+            Same spot on all {pageCount} pages
+          </button>
+          <p className="text-xs text-slate-500 dark:text-dark-text-muted">
+            Copies the placed code to every page at the same position. You can still move, resize,
+            or add a code on any page afterwards.
+          </p>
+        </div>
+      )}
+
+      <PrimaryAction label="Apply codes" onApply={apply} disabled={count === 0} />
+      <p className="text-xs text-slate-500 dark:text-dark-text-muted">
+        Codes burn in as sharp vector graphics — they stay crisp at any zoom or print size.
+      </p>
+    </div>
   );
 }

--- a/src/editor/panels/CodeStampTool.tsx
+++ b/src/editor/panels/CodeStampTool.tsx
@@ -22,6 +22,7 @@ import { PrimaryAction } from "./PrimaryAction.tsx";
 import { useStageProps } from "../stage.tsx";
 import type { FractionRect } from "../types.ts";
 import {
+  ACCENT,
   type Box,
   CORNER_IDS,
   drawSelectionChrome,
@@ -35,7 +36,6 @@ import { Segmented } from "./WholeDocPanel.tsx";
 
 const TOOL_ID = "qr-stamp";
 const DEFAULT_COLOR = "#111827";
-const ACCENT = "#2563eb";
 const MOVE_THRESHOLD_PX = 4;
 /** Default placement width as a fraction of page width (QR is square-ish; a
  *  barcode is wide, so it starts wider). */

--- a/src/editor/panels/OcrTool.tsx
+++ b/src/editor/panels/OcrTool.tsx
@@ -255,8 +255,10 @@ export function Panel() {
             type="button"
             onClick={makeSearchable}
             disabled={busy}
+            aria-busy={busy}
             className="inline-flex items-center justify-center gap-2 rounded-lg bg-primary-600 px-3 py-2.5 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-40 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2"
           >
+            {busy && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
             {busy ? "Working…" : "Make searchable"}
           </button>
           <button

--- a/src/editor/panels/PrimaryAction.tsx
+++ b/src/editor/panels/PrimaryAction.tsx
@@ -14,6 +14,7 @@
 // OCR (Extract / Make searchable), Attachments (add / remove), Redact & Erase
 // (marks persist and burn at export — the ✓ closes, keeping them).
 
+import { Loader2 } from "lucide-react";
 import { useEffect, useRef } from "react";
 import { useEditorActions, useEditorRead } from "../EditorContext.tsx";
 
@@ -66,12 +67,14 @@ export function PrimaryAction({
       type="button"
       onClick={onApply}
       disabled={!ready}
+      aria-busy={busy}
       className={`inline-flex items-center justify-center gap-2 rounded-lg px-3 py-2.5 text-sm font-semibold text-white transition-colors disabled:opacity-40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${
         danger
           ? "bg-red-600 hover:bg-red-700 focus-visible:ring-red-500"
           : "bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-500"
       } ${className}`}
     >
+      {busy && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
       {busy ? "Working…" : label}
     </button>
   );

--- a/src/editor/panels/SignatureTool.tsx
+++ b/src/editor/panels/SignatureTool.tsx
@@ -1,7 +1,11 @@
 // SignatureTool.tsx — Canvas-placement tool. The Panel captures a signature
 // (draw on the pad or upload an image) into the tool slice; the Stage lets the
-// user TAP a page to drop it and DRAG a placed signature to reposition it
-// (stored as `signature` overlay objects carrying the PNG data-URL in payload).
+// user TAP a page to drop it, DRAG it to reposition, and DRAG A CORNER HANDLE to
+// resize it (aspect-locked, so a signature never stretches). Signatures are
+// stored as `signature` overlay objects carrying the PNG data-URL in payload.
+// An optional opaque background can be placed behind the ink (e.g. to sit a
+// signature cleanly over existing page content); the default is transparent.
+//
 // On Apply, `addSignature` embeds each placed signature as a real image (the
 // page text underneath is untouched), then the signature objects are dropped —
 // they now live in the bytes. Reuses the proven SignaturePad + addSignature
@@ -17,25 +21,70 @@ import { useEditorActions, useEditorRead, useToolSlice } from "../EditorContext.
 import { PrimaryAction } from "./PrimaryAction.tsx";
 import { useStageProps } from "../stage.tsx";
 import type { FractionRect } from "../types.ts";
-import { RangeField } from "./controls.tsx";
+import {
+  type Box,
+  CORNER_IDS,
+  drawSelectionChrome,
+  type HandleId,
+  HANDLE_CURSOR,
+  hitHandle,
+  resizeBBoxAspect,
+} from "../resize-handles.ts";
+import { Switch, TRANSPARENCY_CHECKER } from "./controls.tsx";
 
 const TOOL_ID = "signature";
 const DEFAULT_WIDTH_PCT = 0.28;
 const FALLBACK_ASPECT = 2.5; // typical signature is wider than tall
 const DEFAULT_INK = "#1e293b";
+const DEFAULT_BG = "#ffffff";
+/** Selection chrome + handle affordances use the single Ocean-Blue accent. */
+const ACCENT = "#2563eb";
+/** Pointer travel (device px) before a press counts as a drag, not a tap. */
+const MOVE_THRESHOLD_PX = 4;
 
 interface SigPayload {
   dataUrl: string;
+  /** Opaque background colour (hex) painted behind the ink; absent = transparent. */
+  bgHex?: string;
 }
 
 const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
+const rectToBox = (r: FractionRect): Box => ({ x: r.xPct, y: r.yPct, w: r.wPct, h: r.hPct });
+const boxToRect = (b: Box): FractionRect => ({ xPct: b.x, yPct: b.y, wPct: b.w, hPct: b.h });
+
+/** Composite the (transparent) signature onto an opaque background of `bgHex`,
+ *  returning a new PNG data-URL. Used at Apply so the embedded image already
+ *  carries the chosen backing — preview and output stay identical. */
+function withBackground(dataUrl: string, bgHex: string): Promise<string> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      const c = document.createElement("canvas");
+      c.width = img.naturalWidth || 1;
+      c.height = img.naturalHeight || 1;
+      const ctx = c.getContext("2d");
+      if (!ctx) return resolve(dataUrl);
+      ctx.fillStyle = bgHex;
+      ctx.fillRect(0, 0, c.width, c.height);
+      ctx.drawImage(img, 0, 0);
+      resolve(c.toDataURL("image/png"));
+    };
+    img.onerror = () => resolve(dataUrl);
+    img.src = dataUrl;
+  });
+}
 
 export function Stage() {
   const { doc, selectedPage } = useEditorRead();
-  const { addObject, updateObject, commit } = useEditorActions();
+  const { addObject, updateObject, moveObject, removeObject, patchToolState } = useEditorActions();
   const slice = useToolSlice(TOOL_ID);
   const dataUrl = (slice.dataUrl as string) ?? "";
-  const widthPct = (slice.widthPct as number) ?? DEFAULT_WIDTH_PCT;
+  const selectedId = slice.selectedId as string | undefined;
+  const bgEnabled = (slice.bgEnabled as boolean) ?? false;
+  const bgHex = (slice.bgHex as string) ?? DEFAULT_BG;
+
+  const docRef = useRef(doc);
+  docRef.current = doc;
 
   // Lazy <img> cache so placed signatures can be painted on the overlay canvas.
   // A version counter flips the paintOverlay identity once an image decodes, so
@@ -58,6 +107,19 @@ export function Stage() {
   // Drop every decoded image on unmount so nothing lingers past the tool's life.
   useEffect(() => () => imgCache.current.clear(), []);
 
+  // Pre-decode every placed signature's image on (re)mount. The cache is cleared
+  // on unmount, so without this a signature placed earlier, left unapplied, and
+  // returned to would have no decoded image for the first paint — the box showed
+  // empty even though Apply still embedded it. Decoding here bumps imgVersion
+  // once each image is ready, forcing the preview to repaint in. (Bug fix.)
+  useEffect(() => {
+    for (const o of docRef.current?.objects ?? []) {
+      if (o.kind !== "signature") continue;
+      const url = (o.payload as SigPayload | undefined)?.dataUrl;
+      if (url) getImg(url);
+    }
+  }, [getImg]);
+
   // Prune the cache down to URLs still referenced by a live signature object,
   // plus the currently-staged pad data-URL (read by the place handler for its
   // aspect ratio — it must NOT be evicted even before it's placed).
@@ -74,65 +136,131 @@ export function Stage() {
     }
   }, [doc, dataUrl]);
 
+  // Live, history-free geometry while moving/resizing — committed once on
+  // pointerup so a drag is a single undo step (mirrors the annotate tool).
   const dragRef = useRef<{ id: string; dx: number; dy: number; moved: boolean } | null>(null);
+  const resizeRef = useRef<{
+    id: string;
+    handle: HandleId;
+    sx: number;
+    sy: number;
+    orig: FractionRect;
+    aspect: number;
+  } | null>(null);
+  const [live, setLive] = useState<{ id: string; rect: FractionRect } | null>(null);
+  const [hoverHandle, setHoverHandle] = useState<HandleId | null>(null);
+  const paintWHRef = useRef<{ w: number; h: number }>({ w: 0, h: 0 });
+
+  // Drop selection + any in-flight drag when the focused page changes (and on
+  // mount, so stale cross-page state never lingers).
+  useEffect(() => {
+    dragRef.current = null;
+    resizeRef.current = null;
+    setLive(null);
+    setHoverHandle(null);
+    patchToolState(TOOL_ID, { selectedId: undefined });
+  }, [selectedPage, patchToolState]);
+
+  const sigsOnPage = useCallback(
+    (pageIndex: number) =>
+      (docRef.current?.objects ?? []).filter(
+        (o) => o.kind === "signature" && o.pageIndex === pageIndex && o.rect,
+      ),
+    [],
+  );
+
+  // Resolve a signature's current rect, preferring the live drag/resize preview.
+  const rectOf = useCallback(
+    (id: string, rect: FractionRect): FractionRect => (live && live.id === id ? live.rect : rect),
+    [live],
+  );
 
   const paintOverlay = useCallback(
     (ctx: CanvasRenderingContext2D, w: number, h: number, pageIndex: number) => {
+      paintWHRef.current = { w, h };
       for (const o of doc?.objects ?? []) {
         if (o.kind !== "signature" || o.pageIndex !== pageIndex || !o.rect) continue;
-        const r = o.rect;
+        const r = rectOf(o.id, o.rect);
         const x = r.xPct * w;
         const y = r.yPct * h;
         const bw = r.wPct * w;
         const bh = r.hPct * h;
-        const img = getImg((o.payload as SigPayload | undefined)?.dataUrl ?? "");
+        const payload = o.payload as SigPayload | undefined;
+        if (payload?.bgHex) {
+          ctx.save();
+          ctx.fillStyle = payload.bgHex;
+          ctx.fillRect(x, y, bw, bh);
+          ctx.restore();
+        }
+        const img = getImg(payload?.dataUrl ?? "");
         if (img) ctx.drawImage(img, x, y, bw, bh);
-        ctx.save();
-        ctx.strokeStyle = "rgba(37, 99, 235, 0.9)";
-        ctx.setLineDash([5, 4]);
-        ctx.lineWidth = 1.5;
-        ctx.strokeRect(x, y, bw, bh);
-        ctx.restore();
+        if (o.id === selectedId) {
+          drawSelectionChrome(ctx, rectToBox(r), w, h, { handles: CORNER_IDS, accent: ACCENT });
+        } else {
+          // Unselected: a faint dashed outline so every placed signature stays
+          // discoverable (and visibly present before it's applied).
+          ctx.save();
+          ctx.strokeStyle = "rgba(100, 116, 139, 0.7)";
+          ctx.setLineDash([5, 4]);
+          ctx.lineWidth = 1.25;
+          ctx.strokeRect(x, y, bw, bh);
+          ctx.restore();
+        }
       }
     },
-    // imgVersion: re-derive once a signature image decodes so PdfStage repaints
-    // it in (the overlay identity must change to trigger a repaint).
-    [doc, getImg, imgVersion],
+    [doc, getImg, imgVersion, selectedId, rectOf],
   );
 
   // Find the topmost signature on this page whose box contains the point.
   const hitTest = useCallback(
     (xPct: number, yPct: number) => {
-      const sigs = (doc?.objects ?? []).filter(
-        (o) => o.kind === "signature" && o.pageIndex === selectedPage && o.rect,
-      );
+      const sigs = sigsOnPage(selectedPage);
       for (let i = sigs.length - 1; i >= 0; i--) {
-        const r = sigs[i].rect!;
+        const r = rectOf(sigs[i].id, sigs[i].rect!);
         if (xPct >= r.xPct && xPct <= r.xPct + r.wPct && yPct >= r.yPct && yPct <= r.yPct + r.hPct)
           return sigs[i];
       }
       return null;
     },
-    [doc, selectedPage],
+    [sigsOnPage, selectedPage, rectOf],
   );
 
   useStageProps({
-    cursor: dataUrl ? "copy" : "default",
+    cursor: hoverHandle ? HANDLE_CURSOR[hoverHandle] : dataUrl ? "copy" : "default",
     paintOverlay,
     onPointerDown: (p) => {
+      const { w, h } = paintWHRef.current;
+      // A corner handle of the selected signature wins → start an aspect-locked
+      // resize.
+      const sel = sigsOnPage(selectedPage).find((o) => o.id === selectedId);
+      if (sel?.rect) {
+        const r = rectOf(sel.id, sel.rect);
+        const handle = hitHandle(rectToBox(r), p.xPct * w, p.yPct * h, w, h, CORNER_IDS);
+        if (handle) {
+          resizeRef.current = {
+            id: sel.id,
+            handle,
+            sx: p.xPct,
+            sy: p.yPct,
+            orig: r,
+            aspect: r.hPct > 0 ? r.wPct / r.hPct : 1,
+          };
+          return;
+        }
+      }
+      // Otherwise hit-test a placed signature → select + drag to reposition.
       const hit = hitTest(p.xPct, p.yPct);
       if (hit?.rect) {
-        dragRef.current = {
-          id: hit.id,
-          dx: p.xPct - hit.rect.xPct,
-          dy: p.yPct - hit.rect.yPct,
-          moved: false,
-        };
+        const r = rectOf(hit.id, hit.rect);
+        dragRef.current = { id: hit.id, dx: p.xPct - r.xPct, dy: p.yPct - r.yPct, moved: false };
+        if (selectedId !== hit.id) patchToolState(TOOL_ID, { selectedId: hit.id });
         return;
       }
-      if (!dataUrl) return;
-      // Place a new signature centred on the tap, sized from the panel slider
-      // and the image's own aspect ratio so it never looks squashed.
+      // Empty space: deselect, or place a new signature if one is staged.
+      if (!dataUrl) {
+        if (selectedId) patchToolState(TOOL_ID, { selectedId: undefined });
+        return;
+      }
       const page = doc?.pages[selectedPage];
       const img = imgCache.current.get(dataUrl);
       // Guard naturalHeight too: a 0-height (corrupt) image would make aspect
@@ -141,7 +269,7 @@ export function Stage() {
         img?.naturalWidth && img.naturalHeight
           ? img.naturalWidth / img.naturalHeight
           : FALLBACK_ASPECT;
-      const wPct = widthPct;
+      const wPct = DEFAULT_WIDTH_PCT;
       const hPct =
         page && page.heightPt > 0
           ? (wPct * (page.widthPt / page.heightPt)) / aspect
@@ -152,33 +280,118 @@ export function Stage() {
         wPct,
         hPct,
       };
-      addObject({ kind: "signature", pageIndex: selectedPage, rect, payload: { dataUrl } });
+      const id = addObject({
+        kind: "signature",
+        pageIndex: selectedPage,
+        rect,
+        payload: { dataUrl, ...(bgEnabled ? { bgHex } : {}) },
+      });
+      // Select the new signature so its resize handles appear immediately.
+      if (id) patchToolState(TOOL_ID, { selectedId: id });
     },
     onPointerMove: (p) => {
+      const { w, h } = paintWHRef.current;
+      const rs = resizeRef.current;
+      if (rs) {
+        const nb = resizeBBoxAspect(
+          rectToBox(rs.orig),
+          rs.handle,
+          p.xPct - rs.sx,
+          p.yPct - rs.sy,
+          rs.aspect,
+        );
+        setLive({ id: rs.id, rect: boxToRect(nb) });
+        return;
+      }
       const d = dragRef.current;
-      if (!d) return;
-      const obj = (doc?.objects ?? []).find((o) => o.id === d.id);
-      if (!obj?.rect) return;
-      d.moved = true;
-      updateObject(d.id, {
-        rect: {
-          ...obj.rect,
-          xPct: clamp01(p.xPct - d.dx),
-          yPct: clamp01(p.yPct - d.dy),
-        },
-      });
+      if (d) {
+        const obj = sigsOnPage(selectedPage).find((o) => o.id === d.id);
+        if (!obj?.rect) return;
+        const targetX = p.xPct - d.dx;
+        const targetY = p.yPct - d.dy;
+        if (!d.moved) {
+          const dxPx = (targetX - obj.rect.xPct) * w;
+          const dyPx = (targetY - obj.rect.yPct) * h;
+          if (Math.hypot(dxPx, dyPx) < MOVE_THRESHOLD_PX) return;
+          d.moved = true;
+        }
+        const { wPct, hPct } = obj.rect;
+        setLive({
+          id: d.id,
+          rect: {
+            xPct: clamp01(Math.min(targetX, 1 - wPct)),
+            yPct: clamp01(Math.min(targetY, 1 - hPct)),
+            wPct,
+            hPct,
+          },
+        });
+        return;
+      }
+      // Idle hover: light the resize cursor when over the selected signature's
+      // corner handles.
+      const sel = sigsOnPage(selectedPage).find((o) => o.id === selectedId);
+      const over = sel?.rect
+        ? hitHandle(rectToBox(rectOf(sel.id, sel.rect)), p.xPct * w, p.yPct * h, w, h, CORNER_IDS)
+        : null;
+      setHoverHandle((prev) => (prev === over ? prev : over));
     },
     onPointerUp: () => {
+      const rs = resizeRef.current;
+      resizeRef.current = null;
       const d = dragRef.current;
       dragRef.current = null;
-      if (d?.moved) commit("Move signature");
+      const l = live;
+      setLive(null);
+      if (rs && l && l.id === rs.id) {
+        moveObject(rs.id, { rect: l.rect }, "Resize signature");
+        return;
+      }
+      if (d?.moved && l && l.id === d.id) {
+        moveObject(d.id, { rect: l.rect }, "Move signature");
+      }
     },
-    // Pinch interrupted a reposition drag — abandon it. The live `updateObject`
-    // edits aren't committed (no `commit` call), so undo still sees one step.
+    // Pinch interrupted a drag/resize — abandon it. The live edits aren't
+    // committed (no `moveObject`), so undo still sees one step.
     onPointerCancel: () => {
       dragRef.current = null;
+      resizeRef.current = null;
+      setLive(null);
     },
   });
+
+  // Delete / Backspace removes the selected signature (never while typing).
+  useEffect(() => {
+    if (!selectedId) return;
+    const onKey = (e: KeyboardEvent) => {
+      const el = document.activeElement as HTMLElement | null;
+      if (el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable))
+        return;
+      if (e.key !== "Delete" && e.key !== "Backspace") return;
+      const obj = docRef.current?.objects.find((o) => o.id === selectedId);
+      if (!obj || obj.pageIndex !== selectedPage) return;
+      e.preventDefault();
+      removeObject(selectedId);
+      patchToolState(TOOL_ID, { selectedId: undefined });
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectedId, selectedPage, removeObject, patchToolState]);
+
+  // Toggling background on/off (or its colour) updates the SELECTED signature so
+  // the panel control edits the placed mark, not just the next placement.
+  const prevBgRef = useRef<{ enabled: boolean; hex: string } | null>(null);
+  useEffect(() => {
+    const prev = prevBgRef.current;
+    prevBgRef.current = { enabled: bgEnabled, hex: bgHex };
+    if (!prev || (prev.enabled === bgEnabled && prev.hex === bgHex)) return;
+    if (!selectedId) return;
+    const obj = docRef.current?.objects.find((o) => o.id === selectedId);
+    if (obj?.kind !== "signature") return;
+    const payload = obj.payload as SigPayload;
+    updateObject(selectedId, {
+      payload: { dataUrl: payload.dataUrl, ...(bgEnabled ? { bgHex } : {}) },
+    });
+  }, [bgEnabled, bgHex, selectedId, updateObject]);
 
   return null;
 }
@@ -189,8 +402,9 @@ export function Panel() {
   const slice = useToolSlice(TOOL_ID);
   const dataUrl = (slice.dataUrl as string) ?? "";
   const inkHex = (slice.inkHex as string) ?? DEFAULT_INK;
-  const widthPct = (slice.widthPct as number) ?? DEFAULT_WIDTH_PCT;
   const mode = (slice.mode as "draw" | "upload") ?? "draw";
+  const bgEnabled = (slice.bgEnabled as boolean) ?? false;
+  const bgHex = (slice.bgHex as string) ?? DEFAULT_BG;
   const uploadRef = useRef<HTMLInputElement>(null);
 
   const count = (doc?.objects ?? []).filter((o) => o.kind === "signature").length;
@@ -249,7 +463,12 @@ export function Panel() {
         const page = d.pages[o.pageIndex];
         if (!page) continue;
         const r = o.rect!;
-        const url = (o.payload as SigPayload).dataUrl;
+        const payload = o.payload as SigPayload;
+        // Bake an opaque backing into the image when one was chosen, so the
+        // embedded signature matches the on-canvas preview exactly.
+        const url = payload.bgHex
+          ? await withBackground(payload.dataUrl, payload.bgHex)
+          : payload.dataUrl;
         const widthPt = r.wPct * page.widthPt;
         const heightPt = r.hPct * page.heightPt;
         const x = r.xPct * page.widthPt;
@@ -327,32 +546,49 @@ export function Panel() {
             onChange={(e) => onUpload(e.target.files?.[0])}
           />
           {dataUrl && (
-            <img
-              src={dataUrl}
-              alt="Signature preview"
-              className="mx-auto max-h-20 rounded-md border border-slate-200 dark:border-dark-border bg-white p-1"
-            />
+            <div
+              className="mx-auto flex max-h-24 w-fit items-center justify-center rounded-md border border-slate-200 p-1 dark:border-dark-border"
+              // The preview mirrors the choice: a transparency checker when the
+              // signature is ink-only (so it never misreads as a white box), or
+              // the chosen colour when a background is on.
+              style={bgEnabled ? { backgroundColor: bgHex } : TRANSPARENCY_CHECKER}
+            >
+              <img src={dataUrl} alt="Signature preview" className="max-h-20" />
+            </div>
           )}
         </div>
       )}
 
-      <RangeField
-        label="Size"
-        value={Math.round(widthPct * 100)}
-        min={10}
-        max={60}
-        suffix="%"
-        onChange={(v) => patchToolState(TOOL_ID, { widthPct: v / 100 })}
-      />
+      {/* Background: ink-only (transparent) by default, or an opaque colour
+          behind the ink — a switch, not a checkbox, so the binary mode reads
+          clearly. */}
+      <div className="flex flex-col gap-3 rounded-xl border border-slate-200 dark:border-dark-border p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-slate-700 dark:text-dark-text">Background</p>
+            <p className="text-xs text-slate-500 dark:text-dark-text-muted">
+              {bgEnabled ? "Solid colour behind the ink" : "Ink only — transparent"}
+            </p>
+          </div>
+          <Switch
+            checked={bgEnabled}
+            onChange={(v) => patchToolState(TOOL_ID, { bgEnabled: v })}
+            label="Signature background"
+          />
+        </div>
+        {bgEnabled && (
+          <ColorPicker value={bgHex} onChange={(hex) => patchToolState(TOOL_ID, { bgHex: hex })} />
+        )}
+      </div>
 
       <p className="rounded-lg bg-slate-50 dark:bg-dark-bg px-3 py-2 text-xs text-slate-500 dark:text-dark-text-muted">
         {dataUrl
-          ? "Tap the page to place it, then drag to reposition."
+          ? "Tap the page to place it, drag to reposition, then pull a corner to resize. Delete removes the selected one."
           : "Draw or upload a signature to begin."}
       </p>
 
       <span className="text-sm text-slate-600 dark:text-dark-text-muted">
-        {count} signature{count === 1 ? "" : "s"}
+        {count} signature{count === 1 ? "" : "s"} placed
       </span>
 
       {count > 0 && pageCount > 1 && (

--- a/src/editor/panels/SignatureTool.tsx
+++ b/src/editor/panels/SignatureTool.tsx
@@ -22,6 +22,7 @@ import { PrimaryAction } from "./PrimaryAction.tsx";
 import { useStageProps } from "../stage.tsx";
 import type { FractionRect } from "../types.ts";
 import {
+  ACCENT,
   type Box,
   CORNER_IDS,
   drawSelectionChrome,
@@ -37,8 +38,6 @@ const DEFAULT_WIDTH_PCT = 0.28;
 const FALLBACK_ASPECT = 2.5; // typical signature is wider than tall
 const DEFAULT_INK = "#1e293b";
 const DEFAULT_BG = "#ffffff";
-/** Selection chrome + handle affordances use the single Ocean-Blue accent. */
-const ACCENT = "#2563eb";
 /** Pointer travel (device px) before a press counts as a drag, not a tap. */
 const MOVE_THRESHOLD_PX = 4;
 

--- a/src/editor/panels/SignatureTool.tsx
+++ b/src/editor/panels/SignatureTool.tsx
@@ -44,13 +44,84 @@ const MOVE_THRESHOLD_PX = 4;
 
 interface SigPayload {
   dataUrl: string;
-  /** Opaque background colour (hex) painted behind the ink; absent = transparent. */
+  /** Legacy: older placed signatures may carry a baked-in bgHex. The background
+   *  is now a single global panel setting (bgEnabled/bgHex in the slice) applied
+   *  to every signature, so this field is ignored on paint/apply. Kept optional
+   *  only so docs persisted before the change still deserialise. */
   bgHex?: string;
 }
 
 const clamp01 = (n: number) => Math.min(1, Math.max(0, n));
 const rectToBox = (r: FractionRect): Box => ({ x: r.xPct, y: r.yPct, w: r.wPct, h: r.hPct });
 const boxToRect = (b: Box): FractionRect => ({ xPct: b.x, yPct: b.y, wPct: b.w, hPct: b.h });
+
+/** Normalise an UPLOADED image so it behaves like a drawn signature: transparent
+ *  everywhere except the ink/logo. A drawn pad signature is already a transparent
+ *  PNG, but uploads vary — and we must handle every combination:
+ *
+ *   • Transparent PNG (already a cutout, incl. a WHITE logo on transparency) →
+ *     respect it untouched. Knocking out white here would erase a white logo.
+ *   • Opaque scan / JPEG / logo on white paper → knock the near-white paper out
+ *     so the "Ink only — transparent" switch actually shows ink only.
+ *
+ *  The gate: if the image ALREADY carries meaningful transparency, trust it and
+ *  return as-is. Only when it is effectively fully opaque do we remove white.
+ *
+ *  White removal gates on the MIN channel so saturated colours and dark ink stay
+ *  fully opaque (red 255,0,0 → min 0 → kept) while only neutral white/grey paper
+ *  ramps out (255,255,255 → min 255 → removed). Returns the original on a
+ *  tainted-canvas read or a decode failure. */
+function whiteToAlpha(dataUrl: string): Promise<string> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      const w = img.naturalWidth || 1;
+      const h = img.naturalHeight || 1;
+      const c = document.createElement("canvas");
+      c.width = w;
+      c.height = h;
+      const ctx = c.getContext("2d", { willReadFrequently: true });
+      if (!ctx) return resolve(dataUrl);
+      ctx.drawImage(img, 0, 0);
+      let data: ImageData;
+      try {
+        data = ctx.getImageData(0, 0, w, h);
+      } catch {
+        return resolve(dataUrl); // cross-origin taint — keep the original
+      }
+      const px = data.data;
+      const total = px.length / 4;
+
+      // Pass 1 — does the upload already carry its own transparency? Count pixels
+      // that aren't fully opaque; a genuine cutout has a large transparent region
+      // while a flat scan/JPEG has ~none. If it's already a cutout, respect it
+      // (this preserves a white logo sitting on transparency).
+      let translucent = 0;
+      for (let i = 3; i < px.length; i += 4) {
+        if (px[i] < 250) translucent++;
+      }
+      if (translucent / total > 0.005) return resolve(dataUrl);
+
+      // Pass 2 — fully opaque upload: knock the near-white paper out to alpha.
+      const HI = 245; // min channel ≥ this (near-white) → fully transparent
+      const LO = 210; // min channel ≤ this → fully opaque (ink/logo kept)
+      for (let i = 0; i < px.length; i += 4) {
+        const m = Math.min(px[i], px[i + 1], px[i + 2]);
+        if (m >= HI) {
+          px[i + 3] = 0;
+        } else if (m > LO) {
+          // Soft edge: ramp the existing alpha down across the neutral band.
+          const t = (m - LO) / (HI - LO);
+          px[i + 3] = Math.round(px[i + 3] * (1 - t));
+        }
+      }
+      ctx.putImageData(data, 0, 0);
+      resolve(c.toDataURL("image/png"));
+    };
+    img.onerror = () => resolve(dataUrl);
+    img.src = dataUrl;
+  });
+}
 
 /** Composite the (transparent) signature onto an opaque background of `bgHex`,
  *  returning a new PNG data-URL. Used at Apply so the embedded image already
@@ -76,7 +147,7 @@ function withBackground(dataUrl: string, bgHex: string): Promise<string> {
 
 export function Stage() {
   const { doc, selectedPage } = useEditorRead();
-  const { addObject, updateObject, moveObject, removeObject, patchToolState } = useEditorActions();
+  const { addObject, moveObject, removeObject, patchToolState } = useEditorActions();
   const slice = useToolSlice(TOOL_ID);
   const dataUrl = (slice.dataUrl as string) ?? "";
   const selectedId = slice.selectedId as string | undefined;
@@ -186,9 +257,12 @@ export function Stage() {
         const bw = r.wPct * w;
         const bh = r.hPct * h;
         const payload = o.payload as SigPayload | undefined;
-        if (payload?.bgHex) {
+        // Background is a single global setting: paint the chosen colour behind
+        // EVERY placed signature the instant the switch is on, so the live
+        // preview always matches what Apply will bake — no selection required.
+        if (bgEnabled) {
           ctx.save();
-          ctx.fillStyle = payload.bgHex;
+          ctx.fillStyle = bgHex;
           ctx.fillRect(x, y, bw, bh);
           ctx.restore();
         }
@@ -208,7 +282,7 @@ export function Stage() {
         }
       }
     },
-    [doc, getImg, imgVersion, selectedId, rectOf],
+    [doc, getImg, imgVersion, selectedId, rectOf, bgEnabled, bgHex],
   );
 
   // Find the topmost signature on this page whose box contains the point.
@@ -284,7 +358,7 @@ export function Stage() {
         kind: "signature",
         pageIndex: selectedPage,
         rect,
-        payload: { dataUrl, ...(bgEnabled ? { bgHex } : {}) },
+        payload: { dataUrl },
       });
       // Select the new signature so its resize handles appear immediately.
       if (id) patchToolState(TOOL_ID, { selectedId: id });
@@ -377,22 +451,6 @@ export function Stage() {
     return () => window.removeEventListener("keydown", onKey);
   }, [selectedId, selectedPage, removeObject, patchToolState]);
 
-  // Toggling background on/off (or its colour) updates the SELECTED signature so
-  // the panel control edits the placed mark, not just the next placement.
-  const prevBgRef = useRef<{ enabled: boolean; hex: string } | null>(null);
-  useEffect(() => {
-    const prev = prevBgRef.current;
-    prevBgRef.current = { enabled: bgEnabled, hex: bgHex };
-    if (!prev || (prev.enabled === bgEnabled && prev.hex === bgHex)) return;
-    if (!selectedId) return;
-    const obj = docRef.current?.objects.find((o) => o.id === selectedId);
-    if (obj?.kind !== "signature") return;
-    const payload = obj.payload as SigPayload;
-    updateObject(selectedId, {
-      payload: { dataUrl: payload.dataUrl, ...(bgEnabled ? { bgHex } : {}) },
-    });
-  }, [bgEnabled, bgHex, selectedId, updateObject]);
-
   return null;
 }
 
@@ -446,10 +504,14 @@ export function Panel() {
     (file: File | undefined) => {
       if (!file) return;
       const reader = new FileReader();
-      reader.onload = () =>
-        patchToolState(TOOL_ID, {
-          dataUrl: typeof reader.result === "string" ? reader.result : "",
-        });
+      reader.onload = async () => {
+        const raw = typeof reader.result === "string" ? reader.result : "";
+        // Knock out the white paper background so an uploaded signature/logo is
+        // transparent ink, matching the drawn-pad path. The Background switch
+        // then composites a solid colour behind it just like a drawn signature.
+        const url = raw ? await whiteToAlpha(raw) : "";
+        patchToolState(TOOL_ID, { dataUrl: url });
+      };
       reader.readAsDataURL(file);
     },
     [patchToolState],
@@ -464,11 +526,9 @@ export function Panel() {
         if (!page) continue;
         const r = o.rect!;
         const payload = o.payload as SigPayload;
-        // Bake an opaque backing into the image when one was chosen, so the
-        // embedded signature matches the on-canvas preview exactly.
-        const url = payload.bgHex
-          ? await withBackground(payload.dataUrl, payload.bgHex)
-          : payload.dataUrl;
+        // Bake the global opaque backing into the image when the switch is on, so
+        // the embedded signature matches the on-canvas preview exactly.
+        const url = bgEnabled ? await withBackground(payload.dataUrl, bgHex) : payload.dataUrl;
         const widthPt = r.wPct * page.widthPt;
         const heightPt = r.hPct * page.heightPt;
         const x = r.xPct * page.widthPt;
@@ -488,7 +548,7 @@ export function Panel() {
         objects: d.objects.filter((o) => o.kind !== "signature"),
       };
     });
-  }, [applyTransform]);
+  }, [applyTransform, bgEnabled, bgHex]);
 
   const modes: { id: "draw" | "upload"; label: string }[] = [
     { id: "draw", label: "Draw" },

--- a/src/editor/panels/StampTools.tsx
+++ b/src/editor/panels/StampTools.tsx
@@ -3,14 +3,22 @@
 // is an option form + Apply (reusing WholeDocPanel for the busy-aware button)
 // with a visual position picker so the layout is obvious without freeform drag.
 // All are additive (page count/geometry unchanged) so overlay objects are
-// preserved. The result shows on the canvas immediately after Apply.
+// preserved.
+//
+// Each tool renders a LIVE preview on the focused page so the placement, size,
+// colour, and format read as WYSIWYG before you commit — Apply then burns the
+// same text into the bytes. The form state therefore lives in the shared tool
+// slice (not local useState) so a sibling Stage can read it, exactly as the
+// watermark tool does. The preview geometry below mirrors each writer in
+// utils/pdf/stamps.ts (margin / position / baseline) so preview == output.
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import type {
   BatesNumberOptions,
   HeaderFooterOptions,
   PageNumberFormat,
   PageNumberOptions,
+  PageNumberPosition,
   WatermarkOptions,
 } from "../../types.ts";
 import {
@@ -29,6 +37,7 @@ import {
   Labeled,
   PositionGrid,
   RangeField,
+  type Rgb,
   TextField,
   Toggle,
   TokenBar,
@@ -39,18 +48,151 @@ import { Segmented, WholeDocPanel } from "./WholeDocPanel.tsx";
 const INK = { r: 30, g: 41, b: 59 };
 const GREY = { r: 100, g: 116, b: 139 };
 
+const HELVETICA = "Helvetica, Arial, sans-serif";
+const COURIER = "'Courier New', Courier, monospace";
+
+const PAGE_NUMBERS_TOOL_ID = "add-page-numbers";
+const HEADER_FOOTER_TOOL_ID = "header-footer";
+const BATES_TOOL_ID = "bates-numbering";
+
+/**
+ * Paint one stamp run onto the overlay, mirroring the pdf-lib writers: the page
+ * point-space maps to the overlay's (zoom-aware) `w`×`h`, so a point size and a
+ * point margin convert through `s = w / widthPt`. `isTop` puts the baseline a
+ * margin + one line down from the top; otherwise a margin up from the bottom —
+ * matching `height - margin - fontSize` vs `margin` in the burn (PDF y is
+ * bottom-up; the canvas is top-down, so the bottom case lands at `h - margin·s`).
+ */
+function paintStampText(
+  ctx: CanvasRenderingContext2D,
+  w: number,
+  h: number,
+  s: number,
+  opts: {
+    text: string;
+    fontSizePt: number;
+    marginPt: number;
+    isTop: boolean;
+    align: "left" | "center" | "right";
+    color: Rgb;
+    fontFamily: string;
+  },
+): void {
+  if (!opts.text.trim()) return;
+  const fontPx = opts.fontSizePt * s;
+  if (fontPx < 1) return;
+  ctx.save();
+  ctx.fillStyle = `rgb(${opts.color.r}, ${opts.color.g}, ${opts.color.b})`;
+  ctx.font = `${fontPx}px ${opts.fontFamily}`;
+  ctx.textBaseline = "alphabetic";
+  const tw = ctx.measureText(opts.text).width;
+  const mx = opts.marginPt * s;
+  const x = opts.align === "left" ? mx : opts.align === "right" ? w - tw - mx : (w - tw) / 2;
+  const baselineY = opts.isTop ? (opts.marginPt + opts.fontSizePt) * s : h - opts.marginPt * s;
+  ctx.fillText(opts.text, x, baselineY);
+  ctx.restore();
+}
+
+/** Decompose a six-cell position into vertical (top?) + horizontal alignment. */
+function splitPosition(p: PageNumberPosition): {
+  isTop: boolean;
+  align: "left" | "center" | "right";
+} {
+  return {
+    isTop: p.startsWith("top"),
+    align: p.endsWith("left") ? "left" : p.endsWith("right") ? "right" : "center",
+  };
+}
+
+// ── Page numbers ───────────────────────────────────────────────────────────
+
+const PAGE_NUMBER_DEFAULTS: PageNumberOptions = {
+  position: "bottom-center",
+  format: "1",
+  fontSize: 12,
+  color: INK,
+  margin: 36,
+  startNumber: 1,
+  firstPage: 1,
+};
+
+function readPageNumbers(slice: Record<string, unknown>): PageNumberOptions {
+  return {
+    position: (slice.position as PageNumberPosition) ?? PAGE_NUMBER_DEFAULTS.position,
+    format: (slice.format as PageNumberFormat) ?? PAGE_NUMBER_DEFAULTS.format,
+    fontSize: (slice.fontSize as number) ?? PAGE_NUMBER_DEFAULTS.fontSize,
+    color: (slice.color as Rgb) ?? PAGE_NUMBER_DEFAULTS.color,
+    margin: (slice.margin as number) ?? PAGE_NUMBER_DEFAULTS.margin,
+    startNumber: (slice.startNumber as number) ?? PAGE_NUMBER_DEFAULTS.startNumber,
+    firstPage: (slice.firstPage as number) ?? PAGE_NUMBER_DEFAULTS.firstPage,
+  };
+}
+
+/** The page-number string for one page — mirrors the format switch in the burn. */
+function formatPageNumber(format: PageNumberFormat, displayNum: number, lastNum: number): string {
+  switch (format) {
+    case "Page 1":
+      return `Page ${displayNum}`;
+    case "1 / N":
+      return `${displayNum} / ${lastNum}`;
+    case "Page 1 of N":
+      return `Page ${displayNum} of ${lastNum}`;
+    default:
+      return `${displayNum}`;
+  }
+}
+
+export function PageNumbersStage() {
+  const { doc, selectedPage } = useEditorRead();
+  const o = readPageNumbers(useToolSlice(PAGE_NUMBERS_TOOL_ID));
+  const page = doc?.pages[selectedPage] ?? null;
+  const widthPt = page?.widthPt ?? 0;
+  const total = doc?.pageCount ?? 1;
+  const { position, format, fontSize, margin, startNumber, firstPage } = o;
+  const { r, g, b } = o.color;
+  const paintOverlay = useCallback(
+    (ctx: CanvasRenderingContext2D, w: number, h: number) => {
+      if (widthPt <= 0) return;
+      // Pages before `firstPage` carry no number (the cover-skip), so the preview
+      // shows nothing there either.
+      if (selectedPage < firstPage - 1) return;
+      const displayNum = selectedPage - (firstPage - 1) + startNumber;
+      const lastNum = total - firstPage + startNumber;
+      const text = formatPageNumber(format, displayNum, lastNum);
+      const { isTop, align } = splitPosition(position);
+      paintStampText(ctx, w, h, w / widthPt, {
+        text,
+        fontSizePt: fontSize,
+        marginPt: margin,
+        isTop,
+        align,
+        color: { r, g, b },
+        fontFamily: HELVETICA,
+      });
+    },
+    [
+      widthPt,
+      selectedPage,
+      firstPage,
+      startNumber,
+      total,
+      format,
+      position,
+      fontSize,
+      margin,
+      r,
+      g,
+      b,
+    ],
+  );
+  useStageProps({ paintOverlay });
+  return null;
+}
+
 export function PageNumbersPanel() {
-  const { applyTransform } = useEditorActions();
-  const [o, setO] = useState<PageNumberOptions>({
-    position: "bottom-center",
-    format: "1",
-    fontSize: 12,
-    color: INK,
-    margin: 36,
-    startNumber: 1,
-    firstPage: 1,
-  });
-  const set = (p: Partial<PageNumberOptions>) => setO({ ...o, ...p });
+  const { applyTransform, patchToolState } = useEditorActions();
+  const o = readPageNumbers(useToolSlice(PAGE_NUMBERS_TOOL_ID));
+  const set = (p: Partial<PageNumberOptions>) => patchToolState(PAGE_NUMBERS_TOOL_ID, p);
   return (
     <WholeDocPanel
       blurb="Stamp page numbers in a corner of every page."
@@ -96,6 +238,8 @@ export function PageNumbersPanel() {
   );
 }
 
+// ── Header & footer ──────────────────────────────────────────────────────────
+
 function TripleRow({
   label,
   values,
@@ -130,22 +274,97 @@ function TripleRow({
   );
 }
 
+const HEADER_FOOTER_DEFAULTS: HeaderFooterOptions = {
+  headerLeft: "",
+  headerCenter: "",
+  headerRight: "",
+  footerLeft: "",
+  footerCenter: "",
+  footerRight: "",
+  fontSize: 10,
+  color: GREY,
+  margin: 36,
+  skipFirstPage: false,
+};
+
+function readHeaderFooter(slice: Record<string, unknown>): HeaderFooterOptions {
+  const str = (k: keyof HeaderFooterOptions) => (slice[k] as string) ?? "";
+  return {
+    headerLeft: str("headerLeft"),
+    headerCenter: str("headerCenter"),
+    headerRight: str("headerRight"),
+    footerLeft: str("footerLeft"),
+    footerCenter: str("footerCenter"),
+    footerRight: str("footerRight"),
+    fontSize: (slice.fontSize as number) ?? HEADER_FOOTER_DEFAULTS.fontSize,
+    color: (slice.color as Rgb) ?? HEADER_FOOTER_DEFAULTS.color,
+    margin: (slice.margin as number) ?? HEADER_FOOTER_DEFAULTS.margin,
+    skipFirstPage: (slice.skipFirstPage as boolean) ?? HEADER_FOOTER_DEFAULTS.skipFirstPage,
+  };
+}
+
+export function HeaderFooterStage() {
+  const { doc, selectedPage } = useEditorRead();
+  const o = readHeaderFooter(useToolSlice(HEADER_FOOTER_TOOL_ID));
+  const page = doc?.pages[selectedPage] ?? null;
+  const widthPt = page?.widthPt ?? 0;
+  const total = doc?.pageCount ?? 1;
+  const fileName = doc?.fileName ?? "";
+  const { fontSize, margin, skipFirstPage } = o;
+  const { r, g, b } = o.color;
+  const slots = [
+    o.headerLeft,
+    o.headerCenter,
+    o.headerRight,
+    o.footerLeft,
+    o.footerCenter,
+    o.footerRight,
+  ];
+  const paintOverlay = useCallback(
+    (ctx: CanvasRenderingContext2D, w: number, h: number) => {
+      if (widthPt <= 0) return;
+      if (skipFirstPage && selectedPage === 0) return;
+      const resolve = (t: string) =>
+        resolveStampTokens(t, {
+          page: selectedPage + 1,
+          total,
+          title: "",
+          filename: baseFileName(fileName),
+          date: new Date(),
+        });
+      const rows: { raw: string; isTop: boolean; align: "left" | "center" | "right" }[] = [
+        { raw: slots[0], isTop: true, align: "left" },
+        { raw: slots[1], isTop: true, align: "center" },
+        { raw: slots[2], isTop: true, align: "right" },
+        { raw: slots[3], isTop: false, align: "left" },
+        { raw: slots[4], isTop: false, align: "center" },
+        { raw: slots[5], isTop: false, align: "right" },
+      ];
+      for (const row of rows) {
+        if (!row.raw.trim()) continue;
+        paintStampText(ctx, w, h, w / widthPt, {
+          text: resolve(row.raw),
+          fontSizePt: fontSize,
+          marginPt: margin,
+          isTop: row.isTop,
+          align: row.align,
+          color: { r, g, b },
+          fontFamily: HELVETICA,
+        });
+      }
+    },
+    // slots spread so each text edit repaints; primitive deps cover the rest.
+    [widthPt, selectedPage, skipFirstPage, total, fileName, fontSize, margin, r, g, b, ...slots],
+  );
+  useStageProps({ paintOverlay });
+  return null;
+}
+
 export function HeaderFooterPanel() {
-  const { applyTransform } = useEditorActions();
+  const { applyTransform, patchToolState } = useEditorActions();
   const { containerProps, insert } = useTokenInsert();
-  const [o, setO] = useState<HeaderFooterOptions>({
-    headerLeft: "",
-    headerCenter: "",
-    headerRight: "",
-    footerLeft: "",
-    footerCenter: "",
-    footerRight: "",
-    fontSize: 10,
-    color: GREY,
-    margin: 36,
-    skipFirstPage: false,
-  });
-  const set = (p: Partial<HeaderFooterOptions>) => setO({ ...o, ...p });
+  const o = readHeaderFooter(useToolSlice(HEADER_FOOTER_TOOL_ID));
+  const set = (p: Partial<HeaderFooterOptions>) => patchToolState(HEADER_FOOTER_TOOL_ID, p);
   const empty =
     !o.headerLeft &&
     !o.headerCenter &&
@@ -196,19 +415,78 @@ export function HeaderFooterPanel() {
   );
 }
 
+// ── Bates numbering ──────────────────────────────────────────────────────────
+
+const BATES_DEFAULTS: BatesNumberOptions = {
+  prefix: "",
+  suffix: "",
+  startNumber: 1,
+  digits: 6,
+  position: "bottom-right",
+  fontSize: 10,
+  color: INK,
+  margin: 36,
+};
+
+function readBates(slice: Record<string, unknown>): BatesNumberOptions {
+  return {
+    prefix: (slice.prefix as string) ?? BATES_DEFAULTS.prefix,
+    suffix: (slice.suffix as string) ?? BATES_DEFAULTS.suffix,
+    startNumber: (slice.startNumber as number) ?? BATES_DEFAULTS.startNumber,
+    digits: (slice.digits as number) ?? BATES_DEFAULTS.digits,
+    position: (slice.position as PageNumberPosition) ?? BATES_DEFAULTS.position,
+    fontSize: (slice.fontSize as number) ?? BATES_DEFAULTS.fontSize,
+    color: (slice.color as Rgb) ?? BATES_DEFAULTS.color,
+    margin: (slice.margin as number) ?? BATES_DEFAULTS.margin,
+  };
+}
+
+export function BatesStage() {
+  const { doc, selectedPage } = useEditorRead();
+  const o = readBates(useToolSlice(BATES_TOOL_ID));
+  const page = doc?.pages[selectedPage] ?? null;
+  const widthPt = page?.widthPt ?? 0;
+  const { prefix, suffix, startNumber, digits, position, fontSize, margin } = o;
+  const { r, g, b } = o.color;
+  const paintOverlay = useCallback(
+    (ctx: CanvasRenderingContext2D, w: number, h: number) => {
+      if (widthPt <= 0) return;
+      const num = startNumber + selectedPage;
+      const text = `${prefix}${String(num).padStart(digits, "0")}${suffix}`;
+      const { isTop, align } = splitPosition(position);
+      paintStampText(ctx, w, h, w / widthPt, {
+        text,
+        fontSizePt: fontSize,
+        marginPt: margin,
+        isTop,
+        align,
+        color: { r, g, b },
+        fontFamily: COURIER,
+      });
+    },
+    [
+      widthPt,
+      selectedPage,
+      prefix,
+      suffix,
+      startNumber,
+      digits,
+      position,
+      fontSize,
+      margin,
+      r,
+      g,
+      b,
+    ],
+  );
+  useStageProps({ paintOverlay });
+  return null;
+}
+
 export function BatesPanel() {
-  const { applyTransform } = useEditorActions();
-  const [o, setO] = useState<BatesNumberOptions>({
-    prefix: "",
-    suffix: "",
-    startNumber: 1,
-    digits: 6,
-    position: "bottom-right",
-    fontSize: 10,
-    color: INK,
-    margin: 36,
-  });
-  const set = (p: Partial<BatesNumberOptions>) => setO({ ...o, ...p });
+  const { applyTransform, patchToolState } = useEditorActions();
+  const o = readBates(useToolSlice(BATES_TOOL_ID));
+  const set = (p: Partial<BatesNumberOptions>) => patchToolState(BATES_TOOL_ID, p);
   return (
     <WholeDocPanel
       blurb="Stamp sequential identifiers for legal & compliance workflows."
@@ -260,12 +538,10 @@ export function BatesPanel() {
 
 // ── Watermark: live-previewed across the focused page ─────────────────────
 //
-// Unlike the other stamp tools, Watermark renders a real-time preview on the
-// canvas so Size / Opacity / Angle / colour read as WYSIWYG before you commit.
-// That needs the Panel's form state to be visible to a sibling Stage component,
-// so it lives in the shared tool slice (not local useState) — both read it via
-// readWatermark. Apply still burns it into the bytes through addWatermark, so
-// the preview geometry below mirrors that function's centre + rotation math.
+// Watermark renders a real-time preview on the canvas so Size / Opacity / Angle /
+// colour read as WYSIWYG before you commit. Apply still burns it into the bytes
+// through addWatermark, so the preview geometry below mirrors that function's
+// centre + rotation math.
 const WATERMARK_TOOL_ID = "stamp-pdf";
 
 const WATERMARK_DEFAULTS: WatermarkOptions = {

--- a/src/editor/panels/controls.tsx
+++ b/src/editor/panels/controls.tsx
@@ -282,3 +282,44 @@ export function Toggle({
     </label>
   );
 }
+
+/** Accessible on/off pill switch — the editor's nicer alternative to a bare
+ *  checkbox for a binary mode (matches the Export modal's switch). */
+export function Switch({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      className={`relative h-6 w-11 shrink-0 rounded-full transition-[color,background-color,transform] active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 ${
+        checked ? "bg-primary-600" : "bg-slate-300 dark:bg-dark-border"
+      }`}
+    >
+      <span
+        className={`absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow-sm transition-transform ${
+          checked ? "translate-x-5" : "translate-x-0"
+        }`}
+      />
+    </button>
+  );
+}
+
+/** A checkerboard CSS background so a transparent image reads as "no background"
+ *  in a preview swatch (instead of an opaque white card that misrepresents it). */
+export const TRANSPARENCY_CHECKER: React.CSSProperties = {
+  backgroundImage:
+    "linear-gradient(45deg,#e2e8f0 25%,transparent 25%),linear-gradient(-45deg,#e2e8f0 25%,transparent 25%),linear-gradient(45deg,transparent 75%,#e2e8f0 75%),linear-gradient(-45deg,transparent 75%,#e2e8f0 75%)",
+  backgroundSize: "12px 12px",
+  backgroundPosition: "0 0,0 6px,6px -6px,-6px 0",
+  backgroundColor: "#f8fafc",
+};

--- a/src/editor/panels/controls.tsx
+++ b/src/editor/panels/controls.tsx
@@ -261,6 +261,9 @@ export function TokenBar({ onInsert }: { onInsert: (token: string) => void }) {
   );
 }
 
+/** A labelled binary setting: text on the left, an on/off {@link Switch} on the
+ *  right. Renders the same pill switch everywhere (the look the design system
+ *  standardised on), so every settings toggle across the editor reads alike. */
 export function Toggle({
   label,
   checked,
@@ -271,15 +274,10 @@ export function Toggle({
   onChange: (v: boolean) => void;
 }) {
   return (
-    <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-dark-text-muted">
-      <input
-        type="checkbox"
-        checked={checked}
-        onChange={(e) => onChange(e.target.checked)}
-        className="h-4 w-4 rounded border-slate-300 text-primary-600 focus-visible:ring-primary-500"
-      />
-      {label}
-    </label>
+    <div className="flex items-center justify-between gap-3 text-sm text-slate-600 dark:text-dark-text-muted">
+      <span className="min-w-0">{label}</span>
+      <Switch checked={checked} onChange={onChange} label={label} />
+    </div>
   );
 }
 

--- a/src/editor/registry.tsx
+++ b/src/editor/registry.tsx
@@ -25,8 +25,11 @@ import * as SmartErase from "./panels/SmartEraseTool.tsx";
 import * as StripFurniture from "./panels/StripFurnitureTool.tsx";
 import {
   BatesPanel,
+  BatesStage,
   HeaderFooterPanel,
+  HeaderFooterStage,
   PageNumbersPanel,
+  PageNumbersStage,
   WatermarkPanel,
   WatermarkStage,
 } from "./panels/StampTools.tsx";
@@ -63,12 +66,14 @@ export const TOOL_IMPL: Record<string, ToolImpl> = {
   // Security panels: load an async report on open, then apply.
   metadata: { Panel: Metadata.Panel },
   "pdf-scrub": { Panel: Scrub.Panel },
-  // Content-additive stamp-family option tools.
-  "add-page-numbers": { Panel: PageNumbersPanel },
-  "header-footer": { Panel: HeaderFooterPanel },
-  "bates-numbering": { Panel: BatesPanel },
-  // QR / barcode: options-only panel that vector-stamps a scannable code.
-  "qr-stamp": { Panel: CodeStamp.Panel },
+  // Content-additive stamp-family tools — each paints a live preview on the
+  // focused page (Stage) before Apply burns the same text into the bytes.
+  "add-page-numbers": { Stage: PageNumbersStage, Panel: PageNumbersPanel },
+  "header-footer": { Stage: HeaderFooterStage, Panel: HeaderFooterPanel },
+  "bates-numbering": { Stage: BatesStage, Panel: BatesPanel },
+  // QR / barcode: place on the page (tap), drag to move, corner-drag to resize;
+  // a vector code burns in at Apply.
+  "qr-stamp": { Stage: CodeStamp.Stage, Panel: CodeStamp.Panel },
   // Watermark: a live-preview Stage (paints the diagonal text as you tune it) +
   // the options Panel; Apply still burns it into the bytes.
   "stamp-pdf": { Stage: WatermarkStage, Panel: WatermarkPanel },

--- a/src/editor/resize-handles.ts
+++ b/src/editor/resize-handles.ts
@@ -153,18 +153,20 @@ export function resizeBBoxAspect(
   const targetY = (north ? orig.y : bottom) + dy;
 
   // Free width/height from the anchor to the pointer, then "contain" to aspect
-  // (follow whichever axis moved least so the box stays under the cursor).
+  // (follow whichever axis moved least so the box stays under the cursor). When
+  // the pointer is wider than the aspect, constrain width to the height; when
+  // taller, keep the width as-is — height is derived from the clamped width below
+  // either way, so there's nothing to assign in the "taller" case.
   let nw = Math.abs(targetX - anchorX);
-  let nh = Math.abs(targetY - anchorY);
-  if (nw / nh > aspect) nw = nh * aspect;
-  else nh = nw / aspect;
+  const nh0 = Math.abs(targetY - anchorY);
+  if (nw / nh0 > aspect) nw = nh0 * aspect;
 
   // Clamp to the page: room available from the anchor in the drag direction.
   const roomX = west ? anchorX : 1 - anchorX;
   const roomY = north ? anchorY : 1 - anchorY;
   const maxW = Math.min(roomX, roomY * aspect);
   nw = Math.min(Math.max(minFrac, nw), Math.max(minFrac, maxW));
-  nh = nw / aspect;
+  const nh = nw / aspect;
 
   const x = west ? anchorX - nw : anchorX;
   const y = north ? anchorY - nh : anchorY;

--- a/src/editor/resize-handles.ts
+++ b/src/editor/resize-handles.ts
@@ -8,6 +8,11 @@
 // painting take the overlay canvas's device-px size so handle slop is constant
 // on screen regardless of zoom. See AnnotateTool / SignatureTool / CodeStampTool.
 
+/** The single Ocean-Blue accent (primary-600) every overlay tool paints its
+ *  selection chrome + handle affordances in. One source of truth so the canvas
+ *  layer can't drift from the design token. */
+export const ACCENT = "#2563eb";
+
 /** The eight resize handles, by compass id. */
 export type HandleId = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
 
@@ -176,7 +181,7 @@ export function drawSelectionChrome(
   h: number,
   opts: { handles?: HandleId[]; accent?: string } = {},
 ): void {
-  const accent = opts.accent ?? "#2563eb";
+  const accent = opts.accent ?? ACCENT;
   const handles = opts.handles ?? HANDLE_IDS;
   const x = b.x * w - SELECT_PAD;
   const y = b.y * h - SELECT_PAD;

--- a/src/editor/resize-handles.ts
+++ b/src/editor/resize-handles.ts
@@ -1,0 +1,225 @@
+// resize-handles.ts — Shared drag-to-resize machinery for placed overlay
+// objects (annotation shapes/boxes, signatures, code stamps). Extracted from
+// AnnotateTool so every "place then drag a handle to resize" tool reads the same
+// geometry, hit-testing, and selection chrome — one source of truth for the
+// eight-handle resize UX across desktop (mouse) and mobile (touch).
+//
+// All boxes are top-left fraction rects (0–1 of the page). Hit-testing and
+// painting take the overlay canvas's device-px size so handle slop is constant
+// on screen regardless of zoom. See AnnotateTool / SignatureTool / CodeStampTool.
+
+/** The eight resize handles, by compass id. */
+export type HandleId = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
+
+export const HANDLE_IDS: HandleId[] = ["nw", "n", "ne", "e", "se", "s", "sw", "w"];
+/** Corner handles only — the set aspect-locked tools (signature, QR) expose so a
+ *  drag always scales proportionally and never distorts the artwork. */
+export const CORNER_IDS: HandleId[] = ["nw", "ne", "se", "sw"];
+
+export const HANDLE_CURSOR: Record<HandleId, string> = {
+  nw: "nwse-resize",
+  n: "ns-resize",
+  ne: "nesw-resize",
+  e: "ew-resize",
+  se: "nwse-resize",
+  s: "ns-resize",
+  sw: "nesw-resize",
+  w: "ew-resize",
+};
+
+/** Hit slop (device px) around a resize handle — generous so a finger can grab
+ *  it on a phone, where the fit-to-screen page renders small. */
+export const HANDLE_TOL_PX = 14;
+/** Painted half-size (device px) of a resize-handle square. */
+export const HANDLE_HALF_PX = 5;
+/** Padding (device px) between a mark's bbox and its selection chrome. */
+export const SELECT_PAD = 3;
+/** Smallest box size (fractions) a resize can shrink a mark to. */
+export const MIN_BOX_FRAC = 0.015;
+
+/** A top-left fraction box. */
+export interface Box {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+/** Device-px centres of the eight handles around a fraction bbox (+chrome pad). */
+export function handleCenters(
+  b: Box,
+  w: number,
+  h: number,
+): Record<HandleId, { x: number; y: number }> {
+  const x0 = b.x * w - SELECT_PAD;
+  const y0 = b.y * h - SELECT_PAD;
+  const x1 = (b.x + b.w) * w + SELECT_PAD;
+  const y1 = (b.y + b.h) * h + SELECT_PAD;
+  const mx = (x0 + x1) / 2;
+  const my = (y0 + y1) / 2;
+  return {
+    nw: { x: x0, y: y0 },
+    n: { x: mx, y: y0 },
+    ne: { x: x1, y: y0 },
+    e: { x: x1, y: my },
+    se: { x: x1, y: y1 },
+    s: { x: mx, y: y1 },
+    sw: { x: x0, y: y1 },
+    w: { x: x0, y: my },
+  };
+}
+
+/** Which handle (if any) the device-px point lands on. `ids` restricts the set
+ *  tested (e.g. corners only for aspect-locked tools). */
+export function hitHandle(
+  b: Box,
+  px: number,
+  py: number,
+  w: number,
+  h: number,
+  ids: HandleId[] = HANDLE_IDS,
+): HandleId | null {
+  const centers = handleCenters(b, w, h);
+  for (const id of ids) {
+    const c = centers[id];
+    if (Math.abs(px - c.x) <= HANDLE_TOL_PX && Math.abs(py - c.y) <= HANDLE_TOL_PX) return id;
+  }
+  return null;
+}
+
+/** Resize a fraction bbox by dragging `handle` by a fraction delta, keeping the
+ *  opposite edge(s) pinned and clamping to a minimum size within the page. */
+export function resizeBBox(
+  orig: Box,
+  handle: HandleId,
+  dx: number,
+  dy: number,
+  minFrac = MIN_BOX_FRAC,
+): Box {
+  let { x, y, w, h } = orig;
+  const right = orig.x + orig.w;
+  const bottom = orig.y + orig.h;
+  if (handle.includes("w")) {
+    x = Math.min(orig.x + dx, right - minFrac);
+    x = Math.max(0, x);
+    w = right - x;
+  }
+  if (handle.includes("e")) {
+    w = Math.max(minFrac, Math.min(orig.w + dx, 1 - orig.x));
+  }
+  if (handle.includes("n")) {
+    y = Math.min(orig.y + dy, bottom - minFrac);
+    y = Math.max(0, y);
+    h = bottom - y;
+  }
+  if (handle.includes("s")) {
+    h = Math.max(minFrac, Math.min(orig.h + dy, 1 - orig.y));
+  }
+  return { x, y, w, h };
+}
+
+/**
+ * Resize a fraction bbox by a CORNER handle while locking its aspect ratio
+ * (`aspect` = w / h). The corner opposite the dragged handle stays pinned; the
+ * box scales uniformly to follow the pointer, then shrinks if needed so it never
+ * leaves the page. Used by aspect-true artwork (signatures, QR codes) so a drag
+ * can never stretch them. Edge handles fall back to free resize.
+ */
+export function resizeBBoxAspect(
+  orig: Box,
+  handle: HandleId,
+  dx: number,
+  dy: number,
+  aspect: number,
+  minFrac = MIN_BOX_FRAC,
+): Box {
+  const isCorner = CORNER_IDS.includes(handle);
+  if (!isCorner || !(aspect > 0)) return resizeBBox(orig, handle, dx, dy, minFrac);
+
+  const west = handle.includes("w");
+  const north = handle.includes("n");
+  const right = orig.x + orig.w;
+  const bottom = orig.y + orig.h;
+  // The pinned (anchor) corner is opposite the dragged one.
+  const anchorX = west ? right : orig.x;
+  const anchorY = north ? bottom : orig.y;
+  // Where the dragged corner wants to go.
+  const targetX = (west ? orig.x : right) + dx;
+  const targetY = (north ? orig.y : bottom) + dy;
+
+  // Free width/height from the anchor to the pointer, then "contain" to aspect
+  // (follow whichever axis moved least so the box stays under the cursor).
+  let nw = Math.abs(targetX - anchorX);
+  let nh = Math.abs(targetY - anchorY);
+  if (nw / nh > aspect) nw = nh * aspect;
+  else nh = nw / aspect;
+
+  // Clamp to the page: room available from the anchor in the drag direction.
+  const roomX = west ? anchorX : 1 - anchorX;
+  const roomY = north ? anchorY : 1 - anchorY;
+  const maxW = Math.min(roomX, roomY * aspect);
+  nw = Math.min(Math.max(minFrac, nw), Math.max(minFrac, maxW));
+  nh = nw / aspect;
+
+  const x = west ? anchorX - nw : anchorX;
+  const y = north ? anchorY - nh : anchorY;
+  return { x, y, w: nw, h: nh };
+}
+
+/** Dashed selection box around a mark's bbox, with square resize handles. Pass
+ *  `handles` to restrict the drawn set (corners only for aspect-locked tools);
+ *  pass an empty array for a move-only mark (corner ticks only). */
+export function drawSelectionChrome(
+  ctx: CanvasRenderingContext2D,
+  b: Box,
+  w: number,
+  h: number,
+  opts: { handles?: HandleId[]; accent?: string } = {},
+): void {
+  const accent = opts.accent ?? "#2563eb";
+  const handles = opts.handles ?? HANDLE_IDS;
+  const x = b.x * w - SELECT_PAD;
+  const y = b.y * h - SELECT_PAD;
+  const bw = b.w * w + SELECT_PAD * 2;
+  const bh = b.h * h + SELECT_PAD * 2;
+  ctx.save();
+  ctx.strokeStyle = accent;
+  ctx.lineWidth = 1.5;
+  ctx.setLineDash([4, 3]);
+  ctx.strokeRect(x, y, bw, bh);
+  ctx.setLineDash([]);
+  if (handles.length > 0) {
+    const centers = handleCenters(b, w, h);
+    ctx.lineWidth = 1.5;
+    for (const id of handles) {
+      const c = centers[id];
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(
+        c.x - HANDLE_HALF_PX,
+        c.y - HANDLE_HALF_PX,
+        HANDLE_HALF_PX * 2,
+        HANDLE_HALF_PX * 2,
+      );
+      ctx.strokeStyle = accent;
+      ctx.strokeRect(
+        c.x - HANDLE_HALF_PX,
+        c.y - HANDLE_HALF_PX,
+        HANDLE_HALF_PX * 2,
+        HANDLE_HALF_PX * 2,
+      );
+    }
+  } else {
+    // Move-only mark: small corner ticks, no grab handles.
+    ctx.fillStyle = accent;
+    const hs = 3;
+    for (const [hx, hy] of [
+      [x, y],
+      [x + bw, y],
+      [x, y + bh],
+      [x + bw, y + bh],
+    ]) {
+      ctx.fillRect(hx - hs, hy - hs, hs * 2, hs * 2);
+    }
+  }
+  ctx.restore();
+}

--- a/src/editor/tools.ts
+++ b/src/editor/tools.ts
@@ -278,10 +278,11 @@ export const EDITOR_TOOLS = [
     id: "qr-stamp",
     name: "QR / barcode",
     railLabel: "QR code",
-    description: "Stamp a scannable QR code or barcode from a URL, ID, or hash.",
+    description:
+      "Place a scannable QR code or barcode from a URL, ID, or hash, then drag to size it.",
     icon: QrCode,
+    mode: "focus",
     group: "stamps",
-    mode: "either",
     status: "ready",
   },
 

--- a/src/standalone/DigitalSignature.tsx
+++ b/src/standalone/DigitalSignature.tsx
@@ -300,7 +300,10 @@ export default function DigitalSignature() {
 
           {/* Existing signatures */}
           {detectingSignatures && (
-            <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-dark-text-muted py-2">
+            <div
+              role="status"
+              className="flex items-center gap-2 text-sm text-slate-500 dark:text-dark-text-muted py-2"
+            >
               <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
               Checking for existing signatures…
             </div>

--- a/src/utils/pdf-operations.ts
+++ b/src/utils/pdf-operations.ts
@@ -63,8 +63,13 @@ export {
   addBatesNumbers,
 } from "./pdf/stamps.ts";
 
-export type { CodeStampType, CodeStampOptions } from "./pdf/codes.ts";
-export { addCodeStamp, encodeCode128B } from "./pdf/codes.ts";
+export type {
+  CodeStampType,
+  CodeStampOptions,
+  CodeArtOptions,
+  CodePlacement,
+} from "./pdf/codes.ts";
+export { addCodeStamp, addCodeStampAt, encodeCode128B } from "./pdf/codes.ts";
 
 export type { TokenContext, TokenDef } from "./pdf/tokens.ts";
 export { STAMP_TOKENS, resolveStampTokens, hasStampToken, baseFileName } from "./pdf/tokens.ts";

--- a/src/utils/pdf-operations.ts
+++ b/src/utils/pdf-operations.ts
@@ -102,10 +102,18 @@ export { erasePdf, renderErasePreview } from "./pdf/erase.ts";
 export type { ScrubCategory, ScrubAnalysis } from "./pdf/scrub.ts";
 export { SCRUB_CATEGORIES, analyzePdfHiddenData, scrubPdf } from "./pdf/scrub.ts";
 
-export type { AnnotationColor, Annotation, TextFontId, FontFamily } from "./pdf/annotate.ts";
+export type {
+  AnnotationColor,
+  Annotation,
+  IconId,
+  IconGeometry,
+  TextFontId,
+  FontFamily,
+} from "./pdf/annotate.ts";
 export {
   annotatePdf,
   decomposeTextFont,
+  iconGeometry,
   resolveTextFont,
   TEXT_BG_HEIGHT_EM,
   TEXT_BG_PAD_EM,

--- a/src/utils/pdf/annotate.ts
+++ b/src/utils/pdf/annotate.ts
@@ -13,6 +13,61 @@ export interface AnnotationColor {
   b: number;
 }
 
+/** Form-filling glyphs the annotate tool can stamp onto a page — the marks you
+ *  reach for filling a PRINTED (non-interactive) form by hand: tick a checkbox,
+ *  cross a box, fill a radio bubble, or circle a choice. */
+export type IconId = "check" | "cross" | "dot" | "circle";
+
+/** A stampable icon's vector geometry, defined ONCE in a unit square (0–1, with
+ *  y pointing DOWN like screen/canvas space). Both the on-canvas preview and the
+ *  pdf-lib burn consume this same description, so what you place is exactly what
+ *  exports. The glyph is drawn into the largest centred square of its box, so it
+ *  never distorts when the box is resized non-square. */
+export interface IconGeometry {
+  /** Polyline strokes (open paths) — each an array of unit-square points. */
+  strokes: { x: number; y: number }[][];
+  /** Optional filled disc (a radio-bubble fill). */
+  disc?: { cx: number; cy: number; r: number };
+  /** Optional outlined ring (circle a choice). */
+  ring?: { cx: number; cy: number; r: number };
+  /** Stroke/ring weight as a fraction of the square side. */
+  weight: number;
+}
+
+export function iconGeometry(icon: IconId): IconGeometry {
+  switch (icon) {
+    case "check":
+      return {
+        weight: 0.14,
+        strokes: [
+          [
+            { x: 0.16, y: 0.54 },
+            { x: 0.4, y: 0.8 },
+            { x: 0.84, y: 0.22 },
+          ],
+        ],
+      };
+    case "cross":
+      return {
+        weight: 0.14,
+        strokes: [
+          [
+            { x: 0.2, y: 0.2 },
+            { x: 0.8, y: 0.8 },
+          ],
+          [
+            { x: 0.8, y: 0.2 },
+            { x: 0.2, y: 0.8 },
+          ],
+        ],
+      };
+    case "circle":
+      return { weight: 0.1, strokes: [], ring: { cx: 0.5, cy: 0.5, r: 0.4 } };
+    case "dot":
+      return { weight: 0, strokes: [], disc: { cx: 0.5, cy: 0.5, r: 0.32 } };
+  }
+}
+
 /** Font for a text annotation: one of three standard-14 families × Bold × Italic
  *  (12 combinations), which every viewer renders natively — no embedding, no
  *  licensing, no file bloat, and the on-canvas preview matches the output via
@@ -95,6 +150,19 @@ export type Annotation =
       /** Optional opaque background drawn behind the text — lets a label sit on
        *  top of (and mask) existing page content. Omit for transparent text. */
       bg?: { color: AnnotationColor; opacity?: number };
+    }
+  | {
+      kind: "icon";
+      pageIndex: number;
+      /** Which form glyph to stamp. */
+      icon: IconId;
+      /** Box (page fractions, top-left origin). The glyph fills the largest
+       *  centred square of this box. */
+      x: number;
+      y: number;
+      w: number;
+      h: number;
+      color: AnnotationColor;
     };
 
 /** Text-font id → the pdf-lib standard font it embeds as. The only place the
@@ -375,6 +443,54 @@ export async function annotatePdf(file: File, annotations: Annotation[]): Promis
         }
       } catch {
         // Un-encodable label — skip it rather than failing every other mark.
+      }
+    } else if (a.kind === "icon") {
+      // Stamp the glyph into the largest centred square of the box, mapping the
+      // unit-square geometry (y-DOWN) into pdf space (y-UP). Same geometry the
+      // canvas preview paints, so placement and output match exactly.
+      const boxX = a.x * W;
+      const topY = (1 - a.y) * H; // top edge of the box in pdf (y-up) space
+      const boxW = a.w * W;
+      const boxH = a.h * H;
+      const s = Math.min(boxW, boxH);
+      const ox = boxX + (boxW - s) / 2; // square's left
+      const oyTop = topY - (boxH - s) / 2; // square's top edge (y-up)
+      const ux = (u: number) => ox + u * s;
+      const uy = (v: number) => oyTop - v * s; // v=0 → top, v=1 → bottom
+      const g = iconGeometry(a.icon);
+      const thickness = Math.max(0.75, g.weight * s);
+      for (const stroke of g.strokes) {
+        for (let i = 1; i < stroke.length; i++) {
+          page.drawLine({
+            start: { x: ux(stroke[i - 1].x), y: uy(stroke[i - 1].y) },
+            end: { x: ux(stroke[i].x), y: uy(stroke[i].y) },
+            thickness,
+            color,
+            lineCap: LineCapStyle.Round,
+          });
+        }
+      }
+      if (g.disc) {
+        page.drawEllipse({
+          x: ux(g.disc.cx),
+          y: uy(g.disc.cy),
+          xScale: g.disc.r * s,
+          yScale: g.disc.r * s,
+          color,
+          borderWidth: 0,
+        });
+      }
+      if (g.ring) {
+        page.drawEllipse({
+          x: ux(g.ring.cx),
+          y: uy(g.ring.cy),
+          xScale: g.ring.r * s,
+          yScale: g.ring.r * s,
+          borderColor: color,
+          borderWidth: Math.max(0.75, g.weight * s),
+          opacity: 0,
+          borderOpacity: 1,
+        });
       }
     }
   }

--- a/src/utils/pdf/codes.ts
+++ b/src/utils/pdf/codes.ts
@@ -353,3 +353,132 @@ export async function addCodeStamp(
 
   return pdf.save();
 }
+
+// ── explicit-rect placement (canvas editor) ─────────────────────────────────
+
+/** A code's target box on one page, in PDF points (bottom-left origin) — the
+ *  geometry the editor's place-then-drag-resize flow produces. */
+export interface CodePlacement {
+  pageIndex: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** The symbology + payload + look, without the corner/size/margin fields
+ *  addCodeStamp uses for auto-placement (the box is supplied per placement). */
+export interface CodeArtOptions {
+  type: CodeStampType;
+  content: string;
+  color: { r: number; g: number; b: number };
+  caption: boolean;
+}
+
+/** Caption block height as a fraction of barcode bar height (font + gap) — the
+ *  same proportion addCodeStamp uses (0.16 font, 0.5·font gap). */
+const BARCODE_CAPTION_RATIO = 0.16 * 1.5;
+
+/**
+ * Stamp a QR code or Code 128 barcode into EXPLICIT per-page boxes, drawn as the
+ * same sharp vector art as {@link addCodeStamp} but sized to fill each box. This
+ * is the editor's place-then-drag-resize path (one box per placed object),
+ * versus addCodeStamp's corner-anchored, fixed-size, multi-page placement.
+ *
+ * @param file - The source PDF.
+ * @param options - Symbology, payload, colour, caption.
+ * @param placements - Per-page target boxes in PDF points.
+ */
+export async function addCodeStampAt(
+  file: File,
+  options: CodeArtOptions,
+  placements: CodePlacement[],
+): Promise<Uint8Array> {
+  const content = options.content.trim();
+  if (!content) throw new Error("Nothing to encode — enter the text or URL for the code.");
+
+  const pdf = await PDFDocument.load(await file.arrayBuffer());
+  const fg = rgb(options.color.r / 255, options.color.g / 255, options.color.b / 255);
+  const white = rgb(1, 1, 1);
+  const allPages = pdf.getPages();
+
+  // Precompute the matrix / pattern once (identical for every placement).
+  let qrCount = 0;
+  let qrIsDark: (row: number, col: number) => boolean = () => false;
+  if (options.type === "qr") {
+    const qr = qrcode(0, "M");
+    qr.addData(content);
+    qr.make();
+    qrCount = qr.getModuleCount();
+    qrIsDark = (row, col) => qr.isDark(row, col);
+  }
+  const barPattern = options.type === "barcode" ? encodeCode128B(content) : "";
+  const barTotalModules = barPattern ? patternModuleWidth(barPattern) + 20 : 0;
+  const needFont = options.type === "barcode" && options.caption;
+  const font = needFont ? await pdf.embedFont(StandardFonts.Helvetica) : null;
+
+  for (const pl of placements) {
+    const page = allPages[pl.pageIndex];
+    if (!page) continue;
+
+    if (options.type === "qr") {
+      // QR is square: use the box's smaller side, top-left anchored within it.
+      const side = Math.max(1, Math.min(pl.width, pl.height));
+      const ox = pl.x;
+      const oy = pl.y + (pl.height - side); // box top
+      page.drawRectangle({ x: ox, y: oy, width: side, height: side, color: white });
+      const quiet = 4;
+      const ms = side / (qrCount + quiet * 2);
+      for (let row = 0; row < qrCount; row++) {
+        for (let col = 0; col < qrCount; col++) {
+          if (!qrIsDark(row, col)) continue;
+          page.drawRectangle({
+            x: ox + (quiet + col) * ms,
+            y: oy + side - (quiet + row + 1) * ms,
+            width: ms,
+            height: ms,
+            color: fg,
+          });
+        }
+      }
+    } else {
+      const boxW = Math.max(1, pl.width);
+      const boxH = Math.max(1, pl.height);
+      // Split the box height into the bar band + (optional) caption block, with
+      // the same proportions addCodeStamp uses so a placed code looks the same.
+      const barH = options.caption ? boxH / (1 + BARCODE_CAPTION_RATIO) : boxH;
+      const captionFontSize = options.caption ? barH * 0.16 : 0;
+      const captionBlock = boxH - barH;
+      const moduleW = boxW / barTotalModules;
+      page.drawRectangle({ x: pl.x, y: pl.y, width: boxW, height: boxH, color: white });
+      const barBottom = pl.y + captionBlock;
+      let cursor = pl.x + 10 * moduleW; // left quiet zone
+      let isBar = true;
+      for (const ch of barPattern) {
+        const runW = Number(ch) * moduleW;
+        if (isBar) {
+          page.drawRectangle({ x: cursor, y: barBottom, width: runW, height: barH, color: fg });
+        }
+        cursor += runW;
+        isBar = !isBar;
+      }
+      if (font && captionFontSize > 0) {
+        let capSize = captionFontSize;
+        let tw = font.widthOfTextAtSize(content, capSize);
+        if (tw > boxW && tw > 0) {
+          capSize = Math.max(4, (capSize * boxW) / tw);
+          tw = font.widthOfTextAtSize(content, capSize);
+        }
+        page.drawText(content, {
+          x: pl.x + (boxW - tw) / 2,
+          y: pl.y + capSize * 0.25,
+          size: capSize,
+          font,
+          color: fg,
+        });
+      }
+    }
+  }
+
+  return pdf.save();
+}

--- a/src/utils/pdf/metadata.ts
+++ b/src/utils/pdf/metadata.ts
@@ -41,7 +41,11 @@ function formatDateForInput(date: Date | undefined): string {
  */
 export async function getPdfMetadata(file: File): Promise<PdfMetadata> {
   const arrayBuffer = await file.arrayBuffer();
-  const pdf = await PDFDocument.load(arrayBuffer, { updateMetadata: false });
+  // Tolerate encrypted files on read, matching getPdfInfo / scrub / compress.
+  const pdf = await PDFDocument.load(arrayBuffer, {
+    updateMetadata: false,
+    ignoreEncryption: true,
+  });
 
   return {
     title: pdf.getTitle() ?? "",
@@ -73,13 +77,19 @@ export async function setPdfMetadata(file: File, metadata: PdfMetadata): Promise
   pdf.setTitle(metadata.title);
   pdf.setAuthor(metadata.author);
   pdf.setSubject(metadata.subject);
-  pdf.setKeywords([metadata.keywords]);
   pdf.setCreator(metadata.creator);
   pdf.setProducer(metadata.producer);
 
-  // Access the Info dictionary to allow removing date entries.
+  // Access the Info dictionary to allow removing entries.
   // getInfoDict() is private on PDFDocument but available at runtime.
   const infoDict = (pdf as unknown as { getInfoDict(): PDFDict }).getInfoDict();
+  // Empty Keywords should clear the entry, not write a non-empty [""] (which a
+  // reader shows as a single blank keyword). Mirrors the date handling below.
+  if (metadata.keywords) {
+    pdf.setKeywords([metadata.keywords]);
+  } else {
+    infoDict.delete(PDFName.of("Keywords"));
+  }
   if (metadata.creationDate) {
     pdf.setCreationDate(new Date(metadata.creationDate));
   } else {

--- a/src/utils/pdf/stamps.ts
+++ b/src/utils/pdf/stamps.ts
@@ -287,8 +287,10 @@ export async function addSignature(
     : await pdf.embedPng(signatureBytes);
 
   const isMap = position instanceof Map;
+  const pageCount = pdf.getPageCount();
 
   for (const idx of pageIndices) {
+    if (idx < 0 || idx >= pageCount) continue; // skip stale/out-of-range indices
     const fallback = isMap ? position.values().next().value : position;
     const pos = isMap ? (position.get(idx) ?? fallback) : position;
     if (!pos) continue;

--- a/src/workers/crypto.worker.ts
+++ b/src/workers/crypto.worker.ts
@@ -35,6 +35,11 @@ const post = (msg: CryptoWorkerResponse): void =>
   (self as unknown as { postMessage: (m: CryptoWorkerResponse) => void }).postMessage(msg);
 
 self.onmessage = (e: MessageEvent<GenerateCertRequest>) => {
+  // A dedicated worker only ever receives messages from the same-origin document
+  // that spawned it (its MessageEvent.origin is the empty string). Reject any
+  // message carrying a foreign origin before touching the payload — defence in
+  // depth against a misrouted/forged event.
+  if (e.origin && e.origin !== self.location.origin) return;
   const data = e.data;
   if (!data || data.type !== "generateCert") return;
   try {

--- a/tests/e2e/editor-features.e2e.ts
+++ b/tests/e2e/editor-features.e2e.ts
@@ -1,0 +1,217 @@
+/**
+ * Multi-fixture verification for the editor's place / preview features, run
+ * across EVERY PDF in tests/fixtures so the flows are proven on digital,
+ * multi-page, and scanned documents alike:
+ *   • Signature  — draw on the pad → place → drag a corner to resize (aspect-locked).
+ *   • QR code    — type content → place → "Same spot on all N pages" → count == pages.
+ *   • Page numbers / Header & footer / Bates — live on-canvas preview (Stage) mounts.
+ *   • Auto-fill  — detect blanks (0 is fine on a scan with no text layer).
+ * Fails on any console / page error on any fixture.
+ *
+ * Requirements: Chrome at CHROME_PATH and the dev server at http://localhost:5173.
+ *
+ * Run:  node --experimental-strip-types tests/e2e/editor-features.e2e.ts
+ */
+
+import { existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "puppeteer-core";
+import { launch } from "puppeteer-core";
+
+const DEV_URL = process.env.E2E_URL ?? "http://localhost:5173";
+const CHROME_PATH =
+  process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const FIXTURE_DIR = resolve(import.meta.dirname, "../fixtures");
+const USER_DATA_DIR =
+  process.env.E2E_USER_DATA_DIR ??
+  resolve(import.meta.dirname, "../.puppeteer-profile-editor-feat");
+
+function fail(msg: string): never {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+if (!existsSync(CHROME_PATH)) fail(`Chrome not found at ${CHROME_PATH} (set CHROME_PATH).`);
+
+const FIXTURES = readdirSync(FIXTURE_DIR).filter((f) => f.toLowerCase().endsWith(".pdf"));
+if (FIXTURES.length === 0) fail("No PDF fixtures found.");
+
+async function pageBox(page: Page) {
+  const img = await page.$('img[alt="Page 1"]');
+  if (!img) fail("Focus page image not found.");
+  const bb = await img.boundingBox();
+  if (!bb) fail("Focus page image has no layout box.");
+  return bb;
+}
+async function tapFrac(page: Page, fx: number, fy: number) {
+  const bb = await pageBox(page);
+  await page.mouse.click(bb.x + bb.width * fx, bb.y + bb.height * fy);
+}
+async function dragFrac(page: Page, from: { x: number; y: number }, to: { x: number; y: number }) {
+  const bb = await pageBox(page);
+  await page.mouse.move(bb.x + bb.width * from.x, bb.y + bb.height * from.y);
+  await page.mouse.down();
+  await page.mouse.move(
+    bb.x + bb.width * ((from.x + to.x) / 2),
+    bb.y + bb.height * ((from.y + to.y) / 2),
+    { steps: 6 },
+  );
+  await page.mouse.move(bb.x + bb.width * to.x, bb.y + bb.height * to.y, { steps: 8 });
+  await page.mouse.up();
+}
+async function waitText(page: Page, re: RegExp, timeout = 30_000) {
+  await page.waitForFunction(
+    (src: string, flags: string) => new RegExp(src, flags).test(document.body.innerText),
+    { timeout },
+    re.source,
+    re.flags,
+  );
+}
+async function clickByText(page: Page, label: string): Promise<boolean> {
+  return page.evaluate((text) => {
+    const els = Array.from(document.querySelectorAll("button, a, [role=button]"));
+    const el = els.find((e) => (e.textContent ?? "").trim().toLowerCase() === text.toLowerCase());
+    if (!el) return false;
+    (el as HTMLElement).click();
+    return true;
+  }, label);
+}
+async function scribblePad(page: Page) {
+  const pad = await page.$('canvas[aria-label^="Signature drawing area"]');
+  if (!pad) fail("Signature pad not found.");
+  const bb = await pad.boundingBox();
+  if (!bb) fail("Signature pad has no box.");
+  const cy = bb.y + bb.height / 2;
+  await page.mouse.move(bb.x + bb.width * 0.2, cy);
+  await page.mouse.down();
+  await page.mouse.move(bb.x + bb.width * 0.5, cy - bb.height * 0.3, { steps: 6 });
+  await page.mouse.move(bb.x + bb.width * 0.8, cy, { steps: 6 });
+  await page.mouse.up();
+}
+/** Total page count from the top-bar "1 / N" indicator. */
+async function pageCount(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const m = document.body.innerText.match(/\b1\s*\/\s*(\d+)\b/);
+    return m ? parseInt(m[1], 10) : 1;
+  });
+}
+
+async function runFixture(page: Page, fixture: string, errors: string[]) {
+  const path = resolve(FIXTURE_DIR, fixture);
+  await page.goto(DEV_URL, { waitUntil: "networkidle2" });
+  await page.evaluate(
+    () =>
+      new Promise<void>((res) => {
+        const r = indexedDB.deleteDatabase("cloakpdf-editor");
+        r.onsuccess = r.onerror = r.onblocked = () => res();
+      }),
+  );
+  await page.waitForSelector("input[type=file]", { timeout: 15_000 });
+  const input = await page.$("input[type=file]");
+  await (input as unknown as { uploadFile: (...p: string[]) => Promise<void> }).uploadFile(path);
+  await page.waitForSelector('img[alt="Page 1"]', { timeout: 30_000 });
+  const pages = await pageCount(page);
+  const bb = await pageBox(page);
+  const aspect = bb.width / bb.height;
+
+  // 1. Signature: draw → place → corner-resize (aspect-locked).
+  await page.click('button[aria-label="Signature"]');
+  await waitText(page, /Draw or upload a signature/i, 10_000);
+  await scribblePad(page);
+  await waitText(page, /Tap the page to place/i, 10_000);
+  await tapFrac(page, 0.45, 0.4);
+  await waitText(page, /\b1 signature\b/i, 10_000);
+  // SE corner of the placed box (default wPct 0.28, aspect from the scribble ~ pad).
+  const sw = 0.28;
+  const sh = (sw * aspect) / 2.4; // rough; the drag just needs to land on/near the handle
+  await dragFrac(
+    page,
+    { x: 0.45 + sw / 2, y: 0.4 + sh / 2 },
+    { x: 0.45 + sw / 2 + 0.1, y: 0.4 + sh / 2 + 0.1 },
+  );
+  await waitText(page, /\b1 signature\b/i, 5_000);
+
+  // 2. QR: place → same spot on all pages → count == pages.
+  await page.click('button[aria-label="QR / barcode"]');
+  await waitText(page, /Enter content to place|Tap the page to place the code/i, 10_000);
+  await page.type('input[placeholder^="https://example"]', "https://cloakpdf.app/v/1");
+  await waitText(page, /Tap the page to place the code/i, 10_000);
+  await tapFrac(page, 0.8, 0.12);
+  await waitText(page, /\b1 code\b/i, 10_000);
+  if (pages > 1) {
+    const clicked = await page.evaluate(() => {
+      const x = [...document.querySelectorAll("button")].find((e) =>
+        /Same spot on all/i.test(e.textContent ?? ""),
+      );
+      if (x) (x as HTMLElement).click();
+      return !!x;
+    });
+    if (!clicked) fail(`[${fixture}] 'Same spot on all pages' button missing.`);
+    await page.waitForFunction(
+      (n: number) => {
+        const m = document.body.innerText.match(/(\d+)\s+codes?\s+placed/i);
+        return m ? parseInt(m[1], 10) === n : false;
+      },
+      { timeout: 10_000 },
+      pages,
+    );
+  }
+
+  // 3. Stamp previews mount (Stage paints live; assert no error + panel active).
+  for (const [label, panelRe] of [
+    ["Page numbers", /Add page numbers/i],
+    ["Header & footer", /Add header . footer/i],
+    ["Bates", /Add Bates numbers/i],
+  ] as const) {
+    await page.click(`button[aria-label="${label}"]`);
+    await waitText(page, panelRe, 10_000);
+    await new Promise((r) => setTimeout(r, 200)); // let the Stage paint a frame
+  }
+
+  // 4. Auto-fill: detect (0 fields is fine on a scan with no text layer).
+  await page.click('button[aria-label="Auto-fill"]');
+  await waitText(page, /Detect fields/i, 10_000);
+  await clickByText(page, "Detect fields");
+  await waitText(page, /fields?\s+·|No blank fields/i, 60_000);
+
+  if (errors.length > 0) {
+    console.error(`✗ [${fixture}] console/page errors:`);
+    for (const e of errors) console.error(`   ${e}`);
+    fail(`Errors on fixture ${fixture}`);
+  }
+  console.log(`  ✓ ${fixture} (${pages} pages)`);
+}
+
+async function main() {
+  const browser = await launch({
+    executablePath: CHROME_PATH,
+    userDataDir: USER_DATA_DIR,
+    headless: true,
+    defaultViewport: { width: 1280, height: 900 },
+  });
+  const page = await browser.newPage();
+  try {
+    page.setDefaultTimeout(30_000);
+    console.log(`→ Testing ${FIXTURES.length} fixtures: ${FIXTURES.join(", ")}`);
+    for (const fixture of FIXTURES) {
+      const errors: string[] = [];
+      const onConsole = (m: import("puppeteer-core").ConsoleMessage) => {
+        if (m.type() === "error") errors.push(m.text());
+      };
+      const onError = (e: unknown) =>
+        errors.push(`pageerror: ${e instanceof Error ? e.message : String(e)}`);
+      page.on("console", onConsole);
+      page.on("pageerror", onError);
+      await runFixture(page, fixture, errors);
+      page.off("console", onConsole);
+      page.off("pageerror", onError);
+    }
+    console.log(`✓ editor-features passed on all ${FIXTURES.length} fixtures.`);
+  } catch (e) {
+    console.error(`✗ Failed: ${e instanceof Error ? e.message : String(e)}`);
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+}
+
+void main();

--- a/tests/e2e/place-resize-mobile.e2e.ts
+++ b/tests/e2e/place-resize-mobile.e2e.ts
@@ -8,7 +8,7 @@
  * Run:  node --experimental-strip-types tests/e2e/place-resize-mobile.e2e.ts
  */
 
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { deflateSync } from "node:zlib";
@@ -21,7 +21,9 @@ const CHROME_PATH =
 const FIXTURE_PATH = resolve(import.meta.dirname, "../fixtures/multipage.pdf");
 const USER_DATA_DIR =
   process.env.E2E_USER_DATA_DIR ?? resolve(import.meta.dirname, "../.puppeteer-profile-editor-m");
-const SHOT_DIR = process.env.SHOT_DIR ?? tmpdir();
+// A per-run unique temp dir (not a predictable path in the shared temp dir) so
+// the screenshots/fixtures can't collide or be pre-created by another process.
+const SHOT_DIR = process.env.SHOT_DIR ?? mkdtempSync(join(tmpdir(), "cloakpdf-e2e-m-"));
 
 function fail(msg: string): never {
   console.error(`✗ ${msg}`);

--- a/tests/e2e/place-resize-mobile.e2e.ts
+++ b/tests/e2e/place-resize-mobile.e2e.ts
@@ -1,0 +1,261 @@
+/**
+ * Mobile (bottom-sheet) visual verification for the place-then-drag-resize UX:
+ * signature and QR placement + corner-resize with touch, at a phone viewport.
+ * Confirms the panels read in the 40%-capped sheet, the signature Size slider is
+ * gone, placement + resize work, and apply runs via the global ✓. Screenshots to
+ * /tmp for review; fails on any console / page error.
+ *
+ * Run:  node --experimental-strip-types tests/e2e/place-resize-mobile.e2e.ts
+ */
+
+import { existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { deflateSync } from "node:zlib";
+import type { ElementHandle, Page } from "puppeteer-core";
+import { launch } from "puppeteer-core";
+
+const DEV_URL = process.env.E2E_URL ?? "http://localhost:5173";
+const CHROME_PATH =
+  process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const FIXTURE_PATH = resolve(import.meta.dirname, "../fixtures/multipage.pdf");
+const USER_DATA_DIR =
+  process.env.E2E_USER_DATA_DIR ?? resolve(import.meta.dirname, "../.puppeteer-profile-editor-m");
+const SHOT_DIR = process.env.SHOT_DIR ?? tmpdir();
+
+function fail(msg: string): never {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+if (!existsSync(CHROME_PATH)) fail(`Chrome not found at ${CHROME_PATH}.`);
+if (!existsSync(FIXTURE_PATH)) fail(`Fixture not found at ${FIXTURE_PATH}.`);
+
+// Minimal solid-colour PNG encoder (so the signature box geometry is known).
+const CRC = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+function crc32(buf: Buffer): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = CRC[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+function chunk(type: string, data: Buffer): Buffer {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length, 0);
+  const tb = Buffer.from(type, "ascii");
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([tb, data])), 0);
+  return Buffer.concat([len, tb, data, crc]);
+}
+function makePng(w: number, h: number, [r, g, b]: [number, number, number]): Buffer {
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0);
+  ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 2;
+  const row = Buffer.alloc(1 + w * 3);
+  for (let x = 0; x < w; x++) {
+    row[1 + x * 3] = r;
+    row[2 + x * 3] = g;
+    row[3 + x * 3] = b;
+  }
+  const raw = Buffer.concat(Array.from({ length: h }, () => row));
+  return Buffer.concat([
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    chunk("IHDR", ihdr),
+    chunk("IDAT", deflateSync(raw)),
+    chunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+async function pageBox(page: Page) {
+  const img = await page.$('img[alt="Page 1"]');
+  if (!img) fail("Focus page image not found.");
+  const bb = await img.boundingBox();
+  if (!bb) fail("Focus page image has no layout box.");
+  return bb;
+}
+async function tapFrac(page: Page, fx: number, fy: number) {
+  const bb = await pageBox(page);
+  await page.mouse.click(bb.x + bb.width * fx, bb.y + bb.height * fy);
+}
+async function dragFrac(page: Page, from: { x: number; y: number }, to: { x: number; y: number }) {
+  const bb = await pageBox(page);
+  await page.mouse.move(bb.x + bb.width * from.x, bb.y + bb.height * from.y);
+  await page.mouse.down();
+  await page.mouse.move(
+    bb.x + bb.width * ((from.x + to.x) / 2),
+    bb.y + bb.height * ((from.y + to.y) / 2),
+    { steps: 6 },
+  );
+  await page.mouse.move(bb.x + bb.width * to.x, bb.y + bb.height * to.y, { steps: 8 });
+  await page.mouse.up();
+}
+async function waitText(page: Page, re: RegExp, timeout = 15_000) {
+  await page.waitForFunction(
+    (src: string, flags: string) => new RegExp(src, flags).test(document.body.innerText),
+    { timeout },
+    re.source,
+    re.flags,
+  );
+}
+async function pickTool(page: Page, name: string) {
+  await page.waitForFunction(() => !document.querySelector('[aria-busy="true"]'), {
+    timeout: 60_000,
+  });
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const toggle = await page.$('button[aria-label="Open tools"]');
+    if (!toggle) break;
+    await toggle.click();
+    const opened = await page
+      .waitForSelector('button[aria-label="Close tools"]', { timeout: 3_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (opened) break;
+  }
+  await page.waitForSelector(`button[aria-label="${name}"]`, { timeout: 10_000 });
+  await page.click(`button[aria-label="${name}"]`);
+  await page.waitForSelector('button[aria-label="Done"]', { timeout: 10_000 });
+}
+async function sheetFraction(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const sheet = document.querySelector('[data-testid="mobile-tool-sheet"]') as HTMLElement | null;
+    const col = sheet?.parentElement as HTMLElement | null;
+    if (!sheet || !col) return -1;
+    const sh = sheet.getBoundingClientRect().height;
+    const ch = col.getBoundingClientRect().height;
+    return ch > 0 ? sh / ch : -1;
+  });
+}
+
+async function main() {
+  const errors: string[] = [];
+  const browser = await launch({
+    executablePath: CHROME_PATH,
+    userDataDir: USER_DATA_DIR,
+    headless: true,
+    defaultViewport: { width: 390, height: 844, isMobile: true, hasTouch: true },
+  });
+  const page = await browser.newPage();
+  try {
+    page.setDefaultTimeout(25_000);
+    page.on("console", (m) => {
+      if (m.type() === "error") errors.push(m.text());
+    });
+    page.on("pageerror", (e: unknown) =>
+      errors.push(`pageerror: ${e instanceof Error ? e.message : String(e)}`),
+    );
+
+    await page.goto(DEV_URL, { waitUntil: "networkidle2" });
+    await page.evaluate(
+      () =>
+        new Promise<void>((res) => {
+          const r = indexedDB.deleteDatabase("cloakpdf-editor");
+          r.onsuccess = r.onerror = r.onblocked = () => res();
+        }),
+    );
+    await page.waitForSelector("input[type=file]", { timeout: 15_000 });
+    const input = await page.$("input[type=file]");
+    await (input as unknown as { uploadFile: (...p: string[]) => Promise<void> }).uploadFile(
+      FIXTURE_PATH,
+    );
+    await page.waitForSelector('img[alt="Page 1"]', { timeout: 20_000 });
+    await page.waitForSelector('button[aria-label="Open tools"]', { timeout: 10_000 });
+    const bb = await pageBox(page);
+    const pageAspect = bb.width / bb.height;
+
+    // ── Signature ──────────────────────────────────────────────────────────
+    await pickTool(page, "Signature");
+    await waitText(page, /Draw or upload a signature/i);
+    const sliders = await page.$$eval('input[type="range"]', (els) => els.length);
+    if (sliders !== 0) fail(`Mobile signature panel still has a slider (${sliders}).`);
+
+    const pngPath = join(SHOT_DIR, "sig-known-m.png");
+    writeFileSync(pngPath, makePng(240, 120, [30, 41, 59]));
+    await page.evaluate(() => {
+      const b = Array.from(document.querySelectorAll("button")).find(
+        (e) => (e.textContent ?? "").trim() === "Upload",
+      );
+      (b as HTMLElement | null)?.click();
+    });
+    const up = (await page.$(
+      'input[accept="image/png,image/jpeg"]',
+    )) as ElementHandle<HTMLInputElement> | null;
+    if (!up) fail("Signature upload input not found.");
+    await up.uploadFile(pngPath);
+    await waitText(page, /Tap the page to place/i);
+
+    const f = await sheetFraction(page);
+    if (f < 0 || f > 0.43) fail(`Signature sheet exceeds 40% cap: ${(f * 100).toFixed(1)}%.`);
+
+    const wPct = 0.28;
+    const hPct = (wPct * pageAspect) / 2;
+    const cx = 0.45;
+    const cy = 0.26; // upper page, clear of the bottom sheet
+    await tapFrac(page, cx, cy);
+    await waitText(page, /\b1 signature\b/i);
+    await page.screenshot({ path: join(SHOT_DIR, "m-sig-1-placed.png") });
+    await dragFrac(
+      page,
+      { x: cx + wPct / 2, y: cy + hPct / 2 },
+      { x: cx + wPct / 2 + 0.12, y: cy + hPct / 2 + 0.12 },
+    );
+    await waitText(page, /\b1 signature\b/i);
+    await page.screenshot({ path: join(SHOT_DIR, "m-sig-2-resized.png") });
+    console.log("  ✓ mobile signature place + corner-resize (no slider, sheet capped)");
+
+    await page.click('button[aria-label="Done"]'); // ✓ applies
+    await page.waitForSelector('button[aria-label="Open tools"]', { timeout: 60_000 });
+    await page.waitForFunction(() => !document.querySelector('[aria-busy="true"]'), {
+      timeout: 60_000,
+    });
+    console.log("  ✓ mobile signature apply (global ✓)");
+
+    // ── QR ───────────────────────────────────────────────────────────────────
+    await pickTool(page, "QR / barcode");
+    await waitText(page, /Enter content to place|Tap the page to place the code/i);
+    await page.type('input[placeholder^="https://example"]', "https://cloakpdf.app/v/9");
+    await waitText(page, /Tap the page to place the code/i);
+    const qcx = 0.35;
+    const qcy = 0.24;
+    await tapFrac(page, qcx, qcy);
+    await waitText(page, /\b1 code\b/i);
+    await page.screenshot({ path: join(SHOT_DIR, "m-qr-1-placed.png") });
+    const qW = 0.18;
+    const qH = qW * pageAspect;
+    await dragFrac(
+      page,
+      { x: qcx + qW / 2, y: qcy + qH / 2 },
+      { x: qcx + qW / 2 + 0.1, y: qcy + qH / 2 + 0.1 },
+    );
+    await waitText(page, /\b1 code\b/i);
+    await page.screenshot({ path: join(SHOT_DIR, "m-qr-2-resized.png") });
+    console.log("  ✓ mobile QR place + corner-resize");
+
+    if (errors.length > 0) {
+      console.error("✗ Console/page errors:");
+      for (const e of errors) console.error(`   ${e}`);
+      process.exit(1);
+    }
+    console.log(`✓ mobile place-resize verification passed — screenshots in ${SHOT_DIR}`);
+  } catch (e) {
+    console.error(`✗ Failed: ${e instanceof Error ? e.message : String(e)}`);
+    if (errors.length) for (const x of errors) console.error(`   ${x}`);
+    try {
+      await page.screenshot({ path: join(SHOT_DIR, "m-place-resize-fail.png") });
+    } catch {
+      /* ignore */
+    }
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+}
+
+void main();

--- a/tests/e2e/place-resize.e2e.ts
+++ b/tests/e2e/place-resize.e2e.ts
@@ -16,7 +16,7 @@
  * Run:  node --experimental-strip-types tests/e2e/place-resize.e2e.ts
  */
 
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { deflateSync } from "node:zlib";
@@ -29,7 +29,9 @@ const CHROME_PATH =
 const FIXTURE_PATH = resolve(import.meta.dirname, "../fixtures/multipage.pdf");
 const USER_DATA_DIR =
   process.env.E2E_USER_DATA_DIR ?? resolve(import.meta.dirname, "../.puppeteer-profile-editor");
-const SHOT_DIR = process.env.SHOT_DIR ?? tmpdir();
+// A per-run unique temp dir (not a predictable path in the shared temp dir) so
+// the screenshots/fixtures can't collide or be pre-created by another process.
+const SHOT_DIR = process.env.SHOT_DIR ?? mkdtempSync(join(tmpdir(), "cloakpdf-e2e-"));
 
 function fail(msg: string): never {
   console.error(`✗ ${msg}`);

--- a/tests/e2e/place-resize.e2e.ts
+++ b/tests/e2e/place-resize.e2e.ts
@@ -1,0 +1,269 @@
+/**
+ * Visual verification for the place-then-drag-resize UX upgrade:
+ *   • Signature — upload → place → drag a CORNER handle to resize (aspect-locked)
+ *     → toggle an opaque Background → apply. Asserts the Size slider is gone.
+ *   • QR / barcode — type content → place on the page → drag a corner to resize
+ *     → apply (vector burn).
+ *
+ * Drives a real browser and writes screenshots to /tmp for eyeball review, and
+ * fails on any console / page error. A known-aspect (2:1) PNG is uploaded for the
+ * signature so the placed box geometry — and thus the resize-handle location — is
+ * deterministic.
+ *
+ * Requirements: Chrome at CHROME_PATH and the dev server at http://localhost:5173.
+ * Fixture: tests/fixtures/multipage.pdf.
+ *
+ * Run:  node --experimental-strip-types tests/e2e/place-resize.e2e.ts
+ */
+
+import { existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { deflateSync } from "node:zlib";
+import type { ElementHandle, Page } from "puppeteer-core";
+import { launch } from "puppeteer-core";
+
+const DEV_URL = process.env.E2E_URL ?? "http://localhost:5173";
+const CHROME_PATH =
+  process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const FIXTURE_PATH = resolve(import.meta.dirname, "../fixtures/multipage.pdf");
+const USER_DATA_DIR =
+  process.env.E2E_USER_DATA_DIR ?? resolve(import.meta.dirname, "../.puppeteer-profile-editor");
+const SHOT_DIR = process.env.SHOT_DIR ?? tmpdir();
+
+function fail(msg: string): never {
+  console.error(`✗ ${msg}`);
+  process.exit(1);
+}
+if (!existsSync(CHROME_PATH)) fail(`Chrome not found at ${CHROME_PATH} (set CHROME_PATH).`);
+if (!existsSync(FIXTURE_PATH)) fail(`Fixture not found at ${FIXTURE_PATH}.`);
+
+// ── tiny solid-colour PNG encoder (no deps) ────────────────────────────────
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+function crc32(buf: Buffer): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  return (c ^ 0xffffffff) >>> 0;
+}
+function chunk(type: string, data: Buffer): Buffer {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length, 0);
+  const typeBuf = Buffer.from(type, "ascii");
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])), 0);
+  return Buffer.concat([len, typeBuf, data, crc]);
+}
+function makePng(w: number, h: number, [r, g, b]: [number, number, number]): Buffer {
+  const sig = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(w, 0);
+  ihdr.writeUInt32BE(h, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // colour type RGB
+  const row = Buffer.alloc(1 + w * 3);
+  for (let x = 0; x < w; x++) {
+    row[1 + x * 3] = r;
+    row[2 + x * 3] = g;
+    row[3 + x * 3] = b;
+  }
+  const raw = Buffer.concat(Array.from({ length: h }, () => row));
+  return Buffer.concat([
+    sig,
+    chunk("IHDR", ihdr),
+    chunk("IDAT", deflateSync(raw)),
+    chunk("IEND", Buffer.alloc(0)),
+  ]);
+}
+
+async function pageBox(
+  page: Page,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+  const img = await page.$('img[alt="Page 1"]');
+  if (!img) fail("Focus page image not found.");
+  const bb = await img.boundingBox();
+  if (!bb) fail("Focus page image has no layout box.");
+  return bb;
+}
+async function clickFrac(page: Page, fx: number, fy: number): Promise<void> {
+  const bb = await pageBox(page);
+  await page.mouse.click(bb.x + bb.width * fx, bb.y + bb.height * fy);
+}
+async function dragFrac(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number },
+): Promise<void> {
+  const bb = await pageBox(page);
+  await page.mouse.move(bb.x + bb.width * from.x, bb.y + bb.height * from.y);
+  await page.mouse.down();
+  await page.mouse.move(
+    bb.x + bb.width * ((from.x + to.x) / 2),
+    bb.y + bb.height * ((from.y + to.y) / 2),
+    { steps: 6 },
+  );
+  await page.mouse.move(bb.x + bb.width * to.x, bb.y + bb.height * to.y, { steps: 8 });
+  await page.mouse.up();
+}
+async function clickByText(page: Page, label: string): Promise<boolean> {
+  return page.evaluate((text) => {
+    const els = Array.from(document.querySelectorAll("button, a, [role=button]"));
+    const el = els.find((e) => (e.textContent ?? "").trim().toLowerCase() === text.toLowerCase());
+    if (!el) return false;
+    (el as HTMLElement).click();
+    return true;
+  }, label);
+}
+async function waitText(page: Page, re: RegExp, timeout = 15_000): Promise<void> {
+  await page.waitForFunction(
+    (src: string, flags: string) => new RegExp(src, flags).test(document.body.innerText),
+    { timeout },
+    re.source,
+    re.flags,
+  );
+}
+
+async function main() {
+  const errors: string[] = [];
+  const browser = await launch({
+    executablePath: CHROME_PATH,
+    userDataDir: USER_DATA_DIR,
+    headless: true,
+    defaultViewport: { width: 1280, height: 900 },
+  });
+  const page = await browser.newPage();
+  try {
+    page.setDefaultTimeout(20_000);
+    page.on("console", (m) => {
+      if (m.type() === "error") errors.push(m.text());
+    });
+    page.on("pageerror", (e: unknown) =>
+      errors.push(`pageerror: ${e instanceof Error ? e.message : String(e)}`),
+    );
+
+    await page.goto(DEV_URL, { waitUntil: "networkidle2" });
+    await page.evaluate(
+      () =>
+        new Promise<void>((res) => {
+          const r = indexedDB.deleteDatabase("cloakpdf-editor");
+          r.onsuccess = r.onerror = r.onblocked = () => res();
+        }),
+    );
+    await page.waitForSelector("input[type=file]", { timeout: 15_000 });
+    const input = await page.$("input[type=file]");
+    await (input as unknown as { uploadFile: (...p: string[]) => Promise<void> }).uploadFile(
+      FIXTURE_PATH,
+    );
+    await page.waitForSelector('img[alt="Page 1"]', { timeout: 20_000 });
+    const bb = await pageBox(page);
+    const pageAspect = bb.width / bb.height;
+
+    // ── Signature ──────────────────────────────────────────────────────────
+    await page.click('button[aria-label="Signature"]');
+    await waitText(page, /Draw or upload a signature/i);
+
+    // No Size slider any more — the audit's core change.
+    const sliderCount = await page.$$eval('input[type="range"]', (els) => els.length);
+    if (sliderCount !== 0) fail(`Signature panel still shows a slider (${sliderCount}).`);
+    console.log("  ✓ signature Size slider removed");
+
+    // Upload a known 2:1 PNG so the placed box geometry is deterministic.
+    const pngPath = join(SHOT_DIR, "sig-known.png");
+    writeFileSync(pngPath, makePng(240, 120, [30, 41, 59]));
+    if (!(await clickByText(page, "Upload"))) fail("Signature Upload mode not found.");
+    const sigUpload = (await page.$(
+      'input[accept="image/png,image/jpeg"]',
+    )) as ElementHandle<HTMLInputElement> | null;
+    if (!sigUpload) fail("Signature upload input not found.");
+    await sigUpload.uploadFile(pngPath);
+    await waitText(page, /Tap the page to place/i);
+
+    // Place centred at (0.45, 0.4). wPct = 0.28, aspect(img)=2 →
+    // hPct = wPct * pageAspect / 2.
+    const wPct = 0.28;
+    const hPct = (wPct * pageAspect) / 2;
+    const cx = 0.45;
+    const cy = 0.4;
+    await clickFrac(page, cx, cy);
+    await waitText(page, /\b1 signature\b/i);
+    await page.screenshot({ path: join(SHOT_DIR, "sig-1-placed.png") });
+    console.log("  ✓ signature placed (corner handles drawn)");
+
+    // Drag the SE corner handle outward — aspect-locked resize.
+    const seX = cx + wPct / 2;
+    const seY = cy + hPct / 2;
+    await dragFrac(page, { x: seX, y: seY }, { x: seX + 0.14, y: seY + 0.14 });
+    await page.screenshot({ path: join(SHOT_DIR, "sig-2-resized.png") });
+    // Still exactly one signature (resize must not place a second).
+    await waitText(page, /\b1 signature\b/i);
+    console.log("  ✓ signature corner-resize (still 1 signature)");
+
+    // Background switch (ink-only → with background) → recolour to blue.
+    await page.click('button[role="switch"][aria-label="Signature background"]');
+    await page.waitForSelector('button[aria-label^="Blue color"]', { timeout: 5_000 });
+    await page.click('button[aria-label^="Blue color"]');
+    await page.screenshot({ path: join(SHOT_DIR, "sig-3-background.png") });
+    console.log("  ✓ signature background toggle + colour");
+
+    if (!(await clickByText(page, "Apply signature"))) fail("Signature Apply not found.");
+    await waitText(page, /\b0 signatures\b/i, 60_000);
+    console.log("  ✓ signature apply (embedded, object dropped)");
+
+    // ── QR / barcode ─────────────────────────────────────────────────────────
+    await page.click('button[aria-label="QR / barcode"]');
+    await waitText(page, /Enter content to place|Tap the page to place the code/i);
+    await page.type('input[placeholder^="https://example"]', "https://cloakpdf.app/verify/42");
+    await waitText(page, /Tap the page to place the code/i);
+    await page.screenshot({ path: join(SHOT_DIR, "qr-0-preview.png") });
+
+    const qcx = 0.3;
+    const qcy = 0.3;
+    await clickFrac(page, qcx, qcy);
+    await waitText(page, /\b1 code\b/i);
+    await page.screenshot({ path: join(SHOT_DIR, "qr-1-placed.png") });
+    console.log("  ✓ QR placed");
+
+    const qW = 0.18; // DEFAULT_QR_W
+    const qH = qW * pageAspect; // square, aspect 1
+    await dragFrac(
+      page,
+      { x: qcx + qW / 2, y: qcy + qH / 2 },
+      { x: qcx + qW / 2 + 0.12, y: qcy + qH / 2 + 0.12 },
+    );
+    await page.screenshot({ path: join(SHOT_DIR, "qr-2-resized.png") });
+    await waitText(page, /\b1 code\b/i);
+    console.log("  ✓ QR corner-resize (still 1 code)");
+
+    if (!(await clickByText(page, "Apply codes"))) fail("QR Apply not found.");
+    await waitText(page, /\b0 codes\b/i, 60_000);
+    console.log("  ✓ QR apply (vector burn, object dropped)");
+
+    if (errors.length > 0) {
+      console.error("✗ Console/page errors:");
+      for (const e of errors) console.error(`   ${e}`);
+      process.exit(1);
+    }
+    console.log(`✓ place-resize verification passed — screenshots in ${SHOT_DIR}`);
+  } catch (e) {
+    console.error(`✗ Failed: ${e instanceof Error ? e.message : String(e)}`);
+    if (errors.length) for (const x of errors) console.error(`   ${x}`);
+    try {
+      await page.screenshot({ path: join(SHOT_DIR, "place-resize-fail.png") });
+      console.error(`screenshot → ${join(SHOT_DIR, "place-resize-fail.png")}`);
+    } catch {
+      /* ignore */
+    }
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+  }
+}
+
+void main();

--- a/tests/unit/annotate-icons.test.ts
+++ b/tests/unit/annotate-icons.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Coverage for the stampable form-filling icons (tick / cross / dot / circle):
+ *   1. `iconGeometry` returns a well-formed unit-square description for each id
+ *      (points in range, the right primitive set per icon).
+ *   2. `annotatePdf` burns every icon kind without throwing and grows the
+ *      content stream (the glyph actually drew something), and a batch of mixed
+ *      annotations including icons round-trips to a valid PDF.
+ */
+import { PDFDocument } from "@pdfme/pdf-lib";
+import { describe, expect, it } from "vitest";
+import { annotatePdf, type IconId, iconGeometry } from "../../src/utils/pdf-operations.ts";
+
+const ICONS: IconId[] = ["check", "cross", "dot", "circle"];
+
+const toFile = (bytes: Uint8Array) =>
+  new File([bytes as BlobPart], "f.pdf", { type: "application/pdf" });
+const blankPdf = async () => {
+  const doc = await PDFDocument.create({ updateMetadata: false });
+  doc.addPage([300, 400]);
+  return doc.save();
+};
+const black = { r: 0, g: 0, b: 0 };
+
+describe("iconGeometry", () => {
+  it("returns in-range geometry for every icon", () => {
+    for (const id of ICONS) {
+      const g = iconGeometry(id);
+      expect(g.weight).toBeGreaterThanOrEqual(0);
+      for (const stroke of g.strokes) {
+        for (const p of stroke) {
+          expect(p.x).toBeGreaterThanOrEqual(0);
+          expect(p.x).toBeLessThanOrEqual(1);
+          expect(p.y).toBeGreaterThanOrEqual(0);
+          expect(p.y).toBeLessThanOrEqual(1);
+        }
+      }
+      for (const c of [g.disc, g.ring]) {
+        if (!c) continue;
+        expect(c.r).toBeGreaterThan(0);
+        expect(c.r).toBeLessThanOrEqual(0.5);
+      }
+    }
+  });
+
+  it("uses the right primitive per icon", () => {
+    expect(iconGeometry("check").strokes).toHaveLength(1); // single polyline
+    expect(iconGeometry("cross").strokes).toHaveLength(2); // two crossing strokes
+    expect(iconGeometry("dot").disc).toBeDefined(); // filled disc
+    expect(iconGeometry("dot").strokes).toHaveLength(0);
+    expect(iconGeometry("circle").ring).toBeDefined(); // outlined ring
+  });
+});
+
+describe("annotatePdf — icon stamps", () => {
+  it("burns each icon without throwing and emits drawing ops", async () => {
+    const base = await blankPdf();
+    for (const id of ICONS) {
+      const out = await annotatePdf(toFile(base), [
+        {
+          kind: "icon",
+          pageIndex: 0,
+          icon: id,
+          x: 0.4,
+          y: 0.4,
+          w: 0.1,
+          h: 0.1,
+          color: black,
+        },
+      ]);
+      // The stamped page's content stream must be longer than the blank page's.
+      expect(out.length).toBeGreaterThan(base.length);
+      const reopened = await PDFDocument.load(out);
+      expect(reopened.getPageCount()).toBe(1);
+    }
+  });
+
+  it("round-trips a mixed batch (icon + rect + text) to a valid PDF", async () => {
+    const out = await annotatePdf(toFile(await blankPdf()), [
+      { kind: "icon", pageIndex: 0, icon: "check", x: 0.1, y: 0.1, w: 0.08, h: 0.08, color: black },
+      {
+        kind: "rect",
+        pageIndex: 0,
+        x: 0.3,
+        y: 0.3,
+        w: 0.2,
+        h: 0.1,
+        color: black,
+        thicknessFrac: 0.004,
+      },
+      {
+        kind: "text",
+        pageIndex: 0,
+        x: 0.1,
+        y: 0.6,
+        text: "ok",
+        sizeFrac: 0.04,
+        color: black,
+      },
+    ]);
+    const reopened = await PDFDocument.load(out);
+    expect(reopened.getPageCount()).toBe(1);
+  });
+});

--- a/tests/unit/codes.test.ts
+++ b/tests/unit/codes.test.ts
@@ -8,7 +8,13 @@
  */
 import { PDFDocument } from "@pdfme/pdf-lib";
 import { describe, expect, it } from "vitest";
-import { addCodeStamp, type CodeStampOptions, encodeCode128B } from "../../src/utils/pdf/codes.ts";
+import {
+  addCodeStamp,
+  addCodeStampAt,
+  type CodeArtOptions,
+  type CodeStampOptions,
+  encodeCode128B,
+} from "../../src/utils/pdf/codes.ts";
 
 async function makePdf(n: number): Promise<File> {
   const doc = await PDFDocument.create();
@@ -107,5 +113,65 @@ describe("addCodeStamp", () => {
     const loaded = await PDFDocument.load(out);
     expect(loaded.getPageCount()).toBe(1);
     expect(out.byteLength).toBeGreaterThan(before);
+  });
+});
+
+describe("addCodeStampAt", () => {
+  const ART: CodeArtOptions = {
+    type: "qr",
+    content: "https://cloakpdf.app",
+    color: { r: 0, g: 0, b: 0 },
+    caption: true,
+  };
+
+  it("draws a QR at an explicit box on the target page only", async () => {
+    const file = await makePdf(3);
+    const before = (await file.arrayBuffer()).byteLength;
+    const out = await addCodeStampAt(file, ART, [
+      { pageIndex: 1, x: 100, y: 100, width: 120, height: 120 },
+    ]);
+    const doc = await PDFDocument.load(out);
+    expect(doc.getPageCount()).toBe(3);
+    expect(out.byteLength).toBeGreaterThan(before);
+  });
+
+  it("draws a barcode (with caption) into its box", async () => {
+    const file = await makePdf(1);
+    const before = (await file.arrayBuffer()).byteLength;
+    const out = await addCodeStampAt(file, { ...ART, type: "barcode", content: "ABC-0001" }, [
+      { pageIndex: 0, x: 40, y: 60, width: 260, height: 90 },
+    ]);
+    const doc = await PDFDocument.load(out);
+    expect(doc.getPageCount()).toBe(1);
+    expect(out.byteLength).toBeGreaterThan(before);
+  });
+
+  it("burns one code per placement across several pages in one call", async () => {
+    const file = await makePdf(4);
+    const out = await addCodeStampAt(file, ART, [
+      { pageIndex: 0, x: 20, y: 20, width: 80, height: 80 },
+      { pageIndex: 2, x: 400, y: 600, width: 100, height: 100 },
+    ]);
+    const doc = await PDFDocument.load(out);
+    expect(doc.getPageCount()).toBe(4);
+  });
+
+  it("skips out-of-range pages instead of throwing", async () => {
+    const file = await makePdf(1);
+    const out = await addCodeStampAt(file, ART, [
+      { pageIndex: 9, x: 0, y: 0, width: 80, height: 80 },
+    ]);
+    // No valid placement → loadable PDF, unchanged page count.
+    const doc = await PDFDocument.load(out);
+    expect(doc.getPageCount()).toBe(1);
+  });
+
+  it("throws on empty content", async () => {
+    const file = await makePdf(1);
+    await expect(
+      addCodeStampAt(file, { ...ART, content: "  " }, [
+        { pageIndex: 0, x: 0, y: 0, width: 80, height: 80 },
+      ]),
+    ).rejects.toThrow(/Nothing to encode/);
   });
 });

--- a/tests/unit/metadata.test.ts
+++ b/tests/unit/metadata.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Coverage for metadata read/write — in particular the fix where an EMPTY
+ * keywords field must CLEAR the entry rather than write a single blank keyword
+ * (`[""]`), mirroring how the date fields clear.
+ */
+import { PDFDocument } from "@pdfme/pdf-lib";
+import { describe, expect, it } from "vitest";
+import { getPdfMetadata, setPdfMetadata } from "../../src/utils/pdf-operations.ts";
+
+const toFile = (bytes: Uint8Array) =>
+  new File([bytes as BlobPart], "f.pdf", { type: "application/pdf" });
+const blankPdf = async () => {
+  const doc = await PDFDocument.create({ updateMetadata: false });
+  doc.addPage([300, 400]);
+  return doc.save();
+};
+const base = {
+  title: "",
+  author: "",
+  subject: "",
+  keywords: "",
+  creator: "",
+  producer: "",
+  creationDate: "",
+  modificationDate: "",
+};
+
+describe("setPdfMetadata / getPdfMetadata", () => {
+  it("round-trips standard fields", async () => {
+    const out = await setPdfMetadata(toFile(await blankPdf()), {
+      ...base,
+      title: "Hello",
+      author: "Ada",
+      keywords: "a, b, c",
+    });
+    const read = await getPdfMetadata(toFile(out));
+    expect(read.title).toBe("Hello");
+    expect(read.author).toBe("Ada");
+    expect(read.keywords).toBe("a, b, c");
+  });
+
+  it("clears Keywords when empty (no blank [''] entry)", async () => {
+    // First write keywords, then clear them.
+    const withKw = await setPdfMetadata(toFile(await blankPdf()), { ...base, keywords: "x, y" });
+    const cleared = await setPdfMetadata(toFile(withKw), { ...base, keywords: "" });
+    const read = await getPdfMetadata(toFile(cleared));
+    expect(read.keywords).toBe("");
+    // The raw Keywords entry must be gone, not present-but-empty.
+    const doc = await PDFDocument.load(cleared);
+    expect(doc.getKeywords() ?? "").toBe("");
+  });
+});

--- a/tests/unit/resize-handles.test.ts
+++ b/tests/unit/resize-handles.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the shared drag-to-resize machinery (resize-handles.ts) that
+ * powers the editor's place-then-drag-resize tools (annotation shapes/boxes,
+ * signatures, code stamps). Geometry is pure and resolution-independent, so we
+ * pin the handle hit-testing, free resize (opposite edge pinned + min clamp),
+ * and aspect-locked corner resize (never distorts, stays on the page).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  type Box,
+  CORNER_IDS,
+  handleCenters,
+  hitHandle,
+  MIN_BOX_FRAC,
+  resizeBBox,
+  resizeBBoxAspect,
+} from "../../src/editor/resize-handles.ts";
+
+// A 1000×1000 device-px overlay keeps fraction→px conversions easy to read.
+const W = 1000;
+const H = 1000;
+const box: Box = { x: 0.2, y: 0.3, w: 0.4, h: 0.2 }; // px: x 200..600, y 300..500
+
+describe("handleCenters", () => {
+  it("places the eight handles around the padded bbox", () => {
+    const c = handleCenters(box, W, H);
+    // Corners sit just outside the bbox (SELECT_PAD = 3px).
+    expect(c.nw.x).toBeCloseTo(197);
+    expect(c.nw.y).toBeCloseTo(297);
+    expect(c.se.x).toBeCloseTo(603);
+    expect(c.se.y).toBeCloseTo(503);
+    // Edge midpoints are centered on each side.
+    expect(c.n.x).toBeCloseTo((197 + 603) / 2);
+    expect(c.e.y).toBeCloseTo((297 + 503) / 2);
+  });
+});
+
+describe("hitHandle", () => {
+  it("hits a handle within the tolerance and misses outside it", () => {
+    const c = handleCenters(box, W, H);
+    expect(hitHandle(box, c.se.x, c.se.y, W, H)).toBe("se");
+    expect(hitHandle(box, c.se.x + 40, c.se.y + 40, W, H)).toBeNull();
+  });
+
+  it("only reports corner handles when restricted to the corner set", () => {
+    const c = handleCenters(box, W, H);
+    // The east edge midpoint is a handle for the full set but not the corner set.
+    expect(hitHandle(box, c.e.x, c.e.y, W, H)).toBe("e");
+    expect(hitHandle(box, c.e.x, c.e.y, W, H, CORNER_IDS)).toBeNull();
+    expect(hitHandle(box, c.ne.x, c.ne.y, W, H, CORNER_IDS)).toBe("ne");
+  });
+});
+
+describe("resizeBBox (free)", () => {
+  it("drags the SE corner, pinning the NW corner", () => {
+    const r = resizeBBox(box, "se", 0.1, 0.1);
+    expect(r.x).toBeCloseTo(0.2); // NW pinned
+    expect(r.y).toBeCloseTo(0.3);
+    expect(r.w).toBeCloseTo(0.5);
+    expect(r.h).toBeCloseTo(0.3);
+  });
+
+  it("drags the W edge, pinning the right edge", () => {
+    const r = resizeBBox(box, "w", 0.1, 0);
+    expect(r.x).toBeCloseTo(0.3);
+    expect(r.w).toBeCloseTo(0.3); // right edge (0.6) stays put
+    expect(r.y).toBeCloseTo(0.3); // vertical untouched
+    expect(r.h).toBeCloseTo(0.2);
+  });
+
+  it("clamps to the minimum box size instead of inverting", () => {
+    const r = resizeBBox(box, "se", -1, -1);
+    expect(r.w).toBeCloseTo(MIN_BOX_FRAC);
+    expect(r.h).toBeCloseTo(MIN_BOX_FRAC);
+  });
+});
+
+describe("resizeBBoxAspect (locked corners)", () => {
+  const sq: Box = { x: 0.4, y: 0.4, w: 0.2, h: 0.2 }; // square, aspect 1
+
+  it("keeps the aspect ratio when dragging a corner", () => {
+    // Pull SE outward by an uneven delta; the box must stay square.
+    const r = resizeBBoxAspect(sq, "se", 0.2, 0.05, 1);
+    expect(r.w / r.h).toBeCloseTo(1);
+    expect(r.x).toBeCloseTo(0.4); // NW anchor pinned
+    expect(r.y).toBeCloseTo(0.4);
+  });
+
+  it("preserves a non-square aspect (e.g. a wide barcode)", () => {
+    const wide: Box = { x: 0.1, y: 0.4, w: 0.4, h: 0.1 }; // aspect 4
+    const r = resizeBBoxAspect(wide, "se", 0.1, 0.3, 4);
+    expect(r.w / r.h).toBeCloseTo(4);
+  });
+
+  it("never leaves the page when a corner is dragged past an edge", () => {
+    const r = resizeBBoxAspect(sq, "se", 5, 5, 1); // yank far beyond the page
+    expect(r.x + r.w).toBeLessThanOrEqual(1 + 1e-9);
+    expect(r.y + r.h).toBeLessThanOrEqual(1 + 1e-9);
+    expect(r.w / r.h).toBeCloseTo(1); // still square
+  });
+
+  it("pins the opposite corner when dragging NW", () => {
+    const r = resizeBBoxAspect(sq, "nw", -0.1, -0.1, 1);
+    // SE corner (0.6, 0.6) stays fixed.
+    expect(r.x + r.w).toBeCloseTo(0.6);
+    expect(r.y + r.h).toBeCloseTo(0.6);
+    expect(r.w / r.h).toBeCloseTo(1);
+  });
+
+  it("falls back to free resize for an edge handle", () => {
+    const r = resizeBBoxAspect(sq, "e", 0.1, 0, 1);
+    expect(r.w).toBeCloseTo(0.3); // width grew, height unchanged (not locked)
+    expect(r.h).toBeCloseTo(0.2);
+  });
+});


### PR DESCRIPTION
Recent editor batch on `feature/redesign` (5 commits), bringing the canvas editor's placement model to parity across tools, a new form-filling feature, and a broad consistency/robustness audit.

## Highlights

### Placement model — place → drag → corner-resize, everywhere
- Signatures, QR/barcode stamps, and annotate icons share one resize machinery (`resize-handles.ts`): tap to place, drag to move, pull a **corner** to resize (aspect-locked so artwork never distorts). Sliders removed for these; text + multi-page furniture intentionally keep theirs.
- Live on-canvas previews for page numbers / header-footer / Bates (bake on Apply).

### Signatures
- Upload path now knocks out a near-white background so a scanned/JPEG signature behaves like a drawn one — **respecting** images that already carry transparency (a white logo on transparency is kept, not erased).
- Background is a single global switch with a live, faithful preview (ink-only vs solid colour) that matches the burned output.

### Annotate — form-filling icons (new)
- Stamp vector glyphs (**tick / cross / dot / circle**) to fill printed, non-interactive forms by hand.
- Shared unit-square geometry drives both the canvas preview and the pdf-lib burn, so placement ≡ output.
- Unified Icon mode mirrors the signature/QR UX: sticky stamping (many ticks in a row) **and** inline select / move / aspect-locked resize / recolor / retype.

### Codebase audit pass
- `Toggle` now renders the shared pill `Switch` across every panel (one binary-toggle look); dropped a duplicated Switch in `ExportModal`.
- Apply buttons (`PrimaryAction`, OCR "Make searchable") show a spinner + `aria-busy`, matching every other busy button.
- Deduped the `ACCENT` overlay-chrome colour into one constant.
- `metadata`: empty Keywords clears the entry (no blank `['']`); reads tolerate encrypted files. `addSignature` skips out-of-range page indices instead of throwing.
- Focus-ring clip fix; single centered loader for the editor route (was a top spinner then a centered one).

## Tests
- Unit: resize-handles, annotate icons (geometry + burn), metadata, expanded codes — full suite green.
- E2E: `place-resize` (desktop + mobile) and `editor-features` across all 4 fixtures (4–40 pages); build + lint clean.

## Known issue (deferred — tracked, not in this PR)
Vector overlays (signature/QR/annotate) are mis-placed on pages with `/Rotate 90/180/270` because placement maps fractions through the unrotated CropBox. Raster redact/erase are unaffected. This is cross-cutting and needs rotated-PDF fixtures — it deserves its own focused, fixture-backed change rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)